### PR TITLE
Revamp JS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1856 @@
-JavaScript, from Shopify.
+# `import JavaScript from 'Shopify'`
+
+This repository contains everything you should need for writing JavaScript at Shopify. In it you’ll find such things as our linting configs, custom linting rules, and project generators. Below, you’ll find the most important thing: a living styleguide documenting how and why we write JavaScript the way we do.
+
+> Why? All code in any code-base should look like a single person typed it, no matter how many people contributed. If we all follow along with the rules detailed below, we can focus our efforts on more meaningful problems.
+
+
+
+## Table of contents
+
+1. [Using this guide](#using-this-guide)
+1. [Naming](#naming)
+1. [Punctuation](#punctuation)
+1. [Whitespace](#whitespace)
+1. [References](#references)
+1. [Control flow](#control-flow)
+1. [Objects](#objects)
+1. [Arrays](#arrays)
+1. [Strings](#strings)
+1. [Functions](#functions)
+1. [Types and casting](#types-and-casting)
+1. [ES2015 features](#es2015-features)
+1. [Resources](#resources)
+
+There are a few additional styleguides for libraries commonly used at Shopify that serve to augment this guide:
+
+- [jQuery styleguide](jquery/)
+- [React styleguide](react/)
+
+Have a legacy codebase? Can’t use ES2015? Our [legacy styleguide](legacy/) is available in this repo just for you. We also have a dedicated [CoffeeScript styleguide](https://github.com/Shopify/CoffeeScript-Style-Guide) for projects that are still using CoffeeScript (new projects should use ES2015+, though!).
+
+
+
+## Using this guide
+
+Many of the following rules are enforced by our [shared ESLint config](packages/eslint-config-shopify), which you can use in most editors and CI environments. To use it, you will need to have [Node.js and npm installed](https://docs.npmjs.com/getting-started/installing-node). Once these are installed, you have two options for adding ESLint to your project: using our Yeoman generator, or installing everything manually.
+
+### Yeoman Generator
+
+We’ve built a [Yeoman](http://yeoman.io) generator for quickly adding ESLint to your project. First, install Yeoman and the generator globally:
+
+```bash
+npm install -g yo generator-eslint-shopify
+```
+
+Then, use Yeoman’s `yo` command to run the generator, and follow the generator’s prompts.
+
+```bash
+yo eslint-shopify
+```
+
+This generator will install all the required dependencies and add a linting script to your project, so that you can now run the following to run ESLint:
+
+```bash
+npm run lint
+```
+
+### Manually
+
+```bash
+npm install eslint eslint-config-shopify eslint-plugin-shopify --save-dev
+
+# also, if using ES2015+:
+npm install babel-eslint --save-dev
+
+# finally, if using React:
+npm install eslint-plugin-react --save-dev
+```
+
+Once these are installed, you will need to add a `.eslintrc` file at the root of your project that specifies that you'd like to extend the Shopify configuration.
+
+```json
+{
+  "extends": "shopify", // or "shopify/es5" for the ES5 config, "shopify/react" for the React config
+  "parser": "babel-eslint", // unless using ES5
+  "plugins": [
+    "shopify", // add "react" here too if in a React project
+  ],
+  "env": {} // choose your environments: http://eslint.org/docs/user-guide/configuring.html#specifying-environments
+}
+```
+
+You can now use ESLint. The easiest way to do this is by adding a linting script to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "lint": "eslint . --max-warnings 0"
+  }
+}
+```
+
+And, finally, run your new script:
+
+```bash
+npm run lint
+```
+
+
+
+## Naming
+
+- [2.1](#2.1) <a name="2.1"></a> Use camelCase when naming functions, objects, and instances. Snake case is acceptable when interacting with an external API that provides objects with snake-cased keys, like Rails.
+
+  ESLint rule: [`camelcase`](http://eslint.org/docs/rules/camelcase.html)
+
+  ```js
+  // bad
+  const bad_snake_name = 'Larry';
+  const UGLYname = 'this';
+  const badObject = {some_prop: 'some-value'};
+
+  // good
+  const goodSnakeName = 'Basilisk';
+  const prettyName = 'this';
+  const goodObject = {someProp: 'some-value'};
+
+  // not ideal, but sometimes necessary and acceptable
+  const objectProvidedByRails = {some_rails_provided_prop: 'some-value'};
+  ```
+
+- [2.2](#2.2) <a name="2.2"></a> Use PascalCase when naming classes, factories, enumerations, or singletons (cases of enums are written in screaming snake case).
+
+  ESLint rule: [`new-cap`](http://eslint.org/docs/rules/new-cap.html)
+
+  ```js
+  // bad
+  class badClass {}
+  const bad = new badClass();
+
+  const badType = {
+    Water: 0,
+    Fire: 1,
+    Ghost: 2,
+  };
+
+  // good
+  class GoodClass {}
+  const good = new GoodClass();
+
+  const Type = {
+    WATER: 0,
+    FIRE: 1,
+    GHOST: 2,
+  };
+  ```
+
+- [2.3](#2.3) <a name="2.3"></a> Use a leading underscore when naming "private" properties. Functions and variables in scope should be named normally.
+
+  > Why? The leading underscore sends a signal to other developers that these methods should not be called or relied upon. Some tools can also obfuscate methods with leading underscores to ensure that they are not called by outside objects. Items in scope but not exported are completely private, so no signaling is required for these.
+
+  > **Note:** Use these underscore-prefixed members as a last resort. Prefer moving them to be functions/ variables in scope or making them part of the public API over using this naming convention.
+
+  ESLint rule: [`no-underscore-dangle`](http://eslint.org/docs/rules/no-underscore-dangle.html)
+
+  ```js
+  // bad
+  export const bad = {
+    __privateOne__: 0,
+    privateTwo_: 1,
+  };
+
+  function _badPrivateFunctionInScope() {}
+
+  // good
+  export const good = {
+    _private: 0,
+  };
+
+  function goodPrivateFunctionInScope() {}
+  ```
+
+- [2.4](#2.4) <a name="2.4"></a> Avoid single letter names; be descriptive with the names you choose. Note that exceptions can be made for common one-letter identifiers, particularly for use as properties (`x`, `y`, `i`, `j`, `_`).
+
+  ESLint rule: [`id-length`](http://eslint.org/docs/rules/id-length.html)
+
+  ```js
+  // bad
+  const b = 'BAD';
+
+  // good
+  const good = 'GOOD';
+  const point = {
+    x: 10,
+    y: 20,
+  };
+  ```
+
+- [2.5](#2.5) <a name="2.5"></a> Don’t save references to `this`. Use an arrow function (preferred) or `function#bind` instead.
+
+  ```js
+  // bad
+  const badObject = {
+    logSelfAfterTimeout() {
+      const that = this;
+      setTimeout(function() {
+        console.log(that);
+      }, 500);
+    }
+  }
+
+  // better
+  const betterObject = {
+    logSelfAfterTimeout() {
+      setTimeout(function() {
+        console.log(this);
+      }.bind(this), 500);
+    }
+  }
+
+  // best
+  const bestObject = {
+    logSelfAfterTimeout() {
+      setTimeout(() => console.log(this), 500);
+    }
+  }
+  ```
+
+- [2.6](#2.6) <a name="2.6"></a> When naming an event object, use `evt` (as opposed to `e` or `event`).
+
+  ```js
+  // bad
+  function badHandleClickOne(e) {}
+  function badHandleClickTwo(event) {}
+
+  // good
+  function goodHandleClick(evt) {}
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Punctuation
+
+- [3.1](#3.1) <a name="3.1"></a> Always use semicolons.
+
+  ESLint rule: [`semi`](http://eslint.org/docs/rules/semi.html)
+
+  ```js
+  // bad
+  function bad() {
+    const badChoice = 'No semicolons'
+    return badChoice
+  }
+
+  // good
+  function good() {
+    const goodChoice = 'Semicolons';
+    return goodChoice;
+  }
+  ```
+
+- [3.2](#3.2) <a name="3.2"></a> Do not use leading commas.
+
+  > Why? It’s ugly to look at and trailing commas are a better solution to the same problems.
+
+  ESLint rule: [`comma-style`](http://eslint.org/docs/rules/comma-style.html)
+
+  ```js
+  // bad
+  const badOne = {
+      one: 1
+    , two: 2
+    , three: 3
+  };
+
+  const badTwo = [
+      1
+    , 2
+    , 3
+  ];
+
+  // good
+  const goodOne = {
+    one: 1,
+    two: 2,
+    three: 3,
+  };
+
+  const goodTwo = [
+    1,
+    2,
+    3,
+  ];
+  ```
+
+- [3.3](#3.3) <a name="3.3"></a> Objects and arrays should use trailing commas, unless they are on a single line. Commas should always be followed by a space, but never preceded by one.
+
+  > Why? Trailing commas allow you to add and remove a given property of an object without also editing the surrounding lines, which keeps the change isolated to the property in question.
+
+  > **Note:** trailing commas are not permitted in JSON, so be sure to omit them.
+
+  ESLint rules: [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle.html), [`comma-spacing`](http://eslint.org/docs/rules/comma-spacing.html)
+
+  ```javascript
+  // bad
+  const badOne = {
+    foo: 1,
+    bar: 2
+  };
+
+  const badTwo = {foo: 1, bar: 2,};
+
+  const badThree = [
+    1,
+    2
+  ];
+
+  const badFour = [1,2];
+
+  // good
+  const good = {
+    foo: 1,
+    bar: 2,
+  };
+
+  const goodTwo = {foo: 1, bar: 2};
+
+  const goodThree = [
+    1,
+    2,
+  ];
+
+  const goodFour = [1, 2];
+  ```
+
+- [3.4](#3.4) <a name="3.4"></a> Never use commas to separate multiple statements.
+
+  ESLint rule: [`no-sequences`](http://eslint.org/docs/rules/no-sequences.html)
+
+  ```js
+  let a;
+
+  // bad
+  while (a = something(), a != null && a.length !== 0) {
+    // do something
+  }
+
+  // good
+  while (a = something()) {
+    if (a.length === 0) { break; }
+  }
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Whitespace
+
+- [4.1](#4.1) <a name="4.1"></a> In general, add whitespace to improve legibility of code and to group statements together in a way that will produce a more coherent “story” for the next developer to look at code. **Never** optimize for code size: minifiers will do a much better job than you ever could.
+
+- [4.2](#4.2) <a name="4.2"></a> Use two spaces for indentation.
+
+  ESLint rule: [`indent`](http://eslint.org/docs/rules/indent.html)
+
+  ```js
+  // bad
+  function badOne() {
+  ∙∙∙∙return true;
+  }
+
+  function badTwo() {
+  ∙return true;
+  }
+
+  // good
+  function good() {
+  ∙∙return true;
+  }
+  ```
+
+- [4.3](#4.3) <a name="4.3"></a> Use braces for all blocks, including those that are on a single line.
+
+  > Why? Requiring braces prevents issues when a second statement is added to a single-line block.
+
+  ESLint rule: [`curly`](http://eslint.org/docs/rules/curly.html)
+
+  ```js
+  const condition = true;
+
+  // bad
+  if (condition) doSomething();
+  if (condition)
+    doSomething();
+    doSomethingElse(); // will run even if condition is false!
+
+  // good
+  if (condition) { doSomething(); }
+  if (condition) {
+    doSomething();
+    doSomethingElse();
+  }
+  ```
+
+- [4.4](#4.4) <a name="4.4"></a> Place one space before a leading brace. When using `if-else` and `try-catch` constructs, the second part starts on the same line as the closing brace of the first, with a single space between them.
+
+  ESLint rules: [`brace-style`](http://eslint.org/docs/rules/brace-style.html), [`space-before-blocks`](http://eslint.org/docs/rules/space-before-blocks.html)
+
+  ```js
+  // bad
+  function bad()
+  {
+    doSomething();
+  }
+
+  if (condition){ doSomething(); }
+
+  if (otherCondition) {
+    doSomething();
+  }
+  else {
+    doSomethingElse();
+  }
+
+  // good
+  function good() {
+    doSomething();
+  }
+
+  if (condition) { doSomething(); }
+
+  if (otherCondition) {
+    doSomething();
+  } else {
+    doSomethingElse();
+  }
+  ```
+
+- [4.5](#4.5) <a name="4.5"></a> Place one space before the opening parenthesis in control statements (`if`, `while`, etc). Place no space between the function name and argument list in function calls and declarations.
+
+  ESLint rules: [`space-after-keywords`](http://eslint.org/docs/rules/space-after-keywords.html), [`space-before-keywords`](http://eslint.org/docs/rules/space-before-keywords.html)
+
+  ```js
+  // bad
+  if(condition) {
+    doSomething ();
+  }
+
+  function doSomething () {}
+
+  // good
+  if (condition) {
+    doSomething();
+  }
+
+  function doSomething() {}
+  ```
+
+- [4.6](#4.6) <a name="4.6"></a> All operators should be surrounded by spaces.
+
+  ESLint rule: [`space-infix-ops`](http://eslint.org/docs/rules/space-infix-ops.html)
+
+  ```js
+  // bad
+  const bad=34+32;
+
+  // good
+  const good = 1 + 2;
+  ```
+
+- [4.7](#4.7) <a name="4.7"></a> End files with a single newline character. Avoid any end-of-line whitespace.
+
+  ESLint rules: [`eol-last`](http://eslint.org/docs/rules/eol-last.html), [`no-trailing-spaces`](http://eslint.org/docs/rules/no-trailing-spaces.html)
+
+  ```js
+  // bad-one.js
+  const bad = true;
+  ```
+
+  ```js
+  // bad-two.js
+  const bad = true;↵
+  ↵
+  ```
+
+  ```js
+  // bad-three.js
+  const bad = true;∙∙↵
+  ```
+
+  ```js
+  // good.js
+  const good = true;↵
+  ```
+
+- [4.8](#4.8) <a name="4.8"></a> Use indentation when dealing with long method chains. Use a leading dot on each new line.
+
+  > Why? Breaking a method chain across lines improves readability. The leading dot clearly emphasizes that this is a method call, not a new statement.
+
+  ESLint rule: [`dot-location`](http://eslint.org/docs/rules/dot-location.html)
+
+  ```js
+  const result = [1, 2, 3, 4, 5].filter((x) => x > 2).map((x) => x * x * x).reduce((total, x) => total + x, 0);
+
+  // good
+  const result = [1, 2, 3, 4, 5]
+    .filter((x) => x > 2)
+    .map((x) => x * x * x)
+    .reduce((total, x) => total + x, 0);
+  ```
+
+- [4.9](#4.9) <a name="4.9"></a> Do not include extra space inside parentheses, brackets, or curly braces that define an object literal. Include spaces for curly braces that define a single-line function.
+
+  ESLint rules: [`space-in-parens`](http://eslint.org/docs/rules/space-in-parens.html), [`array-bracket-spacing`](http://eslint.org/docs/rules/array-bracket-spacing.html), [`object-curly-spacing`](http://eslint.org/docs/rules/object-curly-spacing.html)
+
+  ```js
+  // bad
+  function badFunction( arg ) {return true;}
+
+  const badObject = { isBad: true };
+  badObject[ 'isBad' ];
+
+  const badArray = [ 1, 2, 3 ];
+
+  // good
+  function goodFunction(arg) { return true; }
+
+  const goodObject = {isGood: true};
+  goodObject['isGood'];
+
+  const goodArray = [1, 2, 3];
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## References
+
+- [5.1](#5.1) <a name="5.1"></a> Always use `let` or `const` (as described in the following rule) to declare variables. Forgetting to do so will result in global variables, which is bad news.
+
+  ESLint rule: [`no-undef`](http://eslint.org/docs/rules/no-undef.html)
+
+  ```js
+  // bad
+  bad = BadChoice();
+
+  // good
+  const good = GoodChoice()
+  ```
+
+- [5.2](#5.2) <a name="5.2"></a> Use [`const`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const) for all references that do not need to be re-assigned. Use [`let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) only for references that will be re-assigned. Never use `var`.
+
+  > Why? `const` and `let` are block scoped, rather than being function-scoped like `var`. `const` indicates that a given reference will always refer to the same object or primitive throughout the current scope, which makes code easier to reason about.
+
+  ESLint rules: [`prefer-const`](http://eslint.org/docs/rules/prefer-const.html), [`no-const-assign`](http://eslint.org/docs/rules/no-const-assign.html), [`no-var`](http://eslint.org/docs/rules/no-var.html)
+
+  ```javascript
+  // bad
+  var CONSTANT_VALUE = 1;
+  var count = 0;
+  if (true) {
+    count += 1;
+  }
+
+  // good
+  const someUnchangingReference = 1;
+  let count = 0;
+  if (true) {
+    count += 1;
+  }
+  ```
+
+- [5.3](#5.3) <a name="5.3"></a> Initialize variables on declaration as often as possible. If a variable has no value until a later point (for example, it is calculated inside a complex conditional expression, or it is a variable in scope that is redeclared for each unit test), you can declare a variable without initialization.
+
+  ESLint rule: [`init-declarations`](http://eslint.org/docs/rules/init-declarations.html)
+
+  ```js
+  // bad
+  let bad = null;
+  // ...
+  bad = 'bad';
+
+  // good
+  const goodOne = 'good';
+
+  // or, if you can't provide a value immediately:
+  let goodTwo;
+  // ...
+  goodTwo = 'good';
+  ```
+
+- [5.4](#5.4) <a name="5.4"></a> don’t refer a reference before it is defined. The only exception to this rule is for functions; use the hoisting feature of functions liberally to allow the primary export of a file to appear first (and any helper or utility functions it uses to appear afterwards).
+
+  ESLint rule: [`no-use-before-define`](http://eslint.org/docs/rules/no-use-before-define.html)
+
+  ```js
+  // bad
+  function bad() {
+    return badVar;
+  }
+
+  const badVar = true;
+
+  // good
+  const goodVar = true;
+
+  function good() {
+    return goodVar;
+  }
+  ```
+
+- [5.5](#5.5) <a name="5.5"></a> Use screaming snake case for file-level constants to make it clear to users that they can’t be modified.
+
+  ```javascript
+  // bad
+  const constantValue = 1;
+
+  // good
+  const CONSTANT_VALUE = 1;
+  ```
+
+- [5.6](#5.6) <a name="5.6"></a> Declare each variable on its own line; never comma-separate your variables on a single line.
+
+  > Why? Listing all variables on a single line makes it harder to scan, and encourages creating too many local variables.
+
+  ESLint rule: [`one-var`](http://eslint.org/docs/rules/one-var.html).
+
+  ```javascript
+  // bad
+  const badFooOne = 'bar', badBazOne = 'qux';
+  const badFooTwo = 'bar',
+      badBazTwo = 'qux';
+
+  // good
+  const goodFoo = 'bar';
+  const goodBaz = 'qux';
+  ```
+
+- [5.7](#5.7) <a name="5.7"></a> Never shadow variable names from outer scopes. Avoid shadowing of names with special meaning, like `arguments`.
+
+  > Why? It makes the code harder to reason about because the purpose of a given variable changes with the scope, and introduces the opportunity for subtle bugs by assigning to the variable when you meant to redeclare it.
+
+  ESLint rules: [`no-shadow`](http://eslint.org/docs/rules/no-shadow.html), [`no-shadow-restricted-names`](http://eslint.org/docs/rules/no-shadow-restricted-names.html)
+
+  ```js
+  // bad
+  function bad() {
+    const arguments = [];
+    const foo = true;
+
+    runCallback(() => {
+      const foo = false;
+      return true;
+    });
+
+    // what is `foo`?
+  }
+
+  // good
+  function good() {
+    const args = [];
+    const foo = true;
+
+    runCallback(() => {
+      const callbackFoo = false;
+      return false;
+    });
+  }
+  ```
+
+- [5.8](#5.8) <a name="5.8"></a> For a given section of code for which you are defining variables (typically, at the top of a block), group all `const` declarations that apply to that entire scope, then group all `let` declarations that apply to the entire scope.
+
+  > Why? It is easier to see all variables that are used, and whether they are able to be re-assigned or not.
+
+  ```js
+  // bad
+  let i = 0;
+  const FOO = true;
+  const bar = 'bar';
+  someUnrelatedCall();
+  const BAZ = false;
+
+  // good
+  const FOO = true;
+  const BAZ = false;
+  const bar = 'bar';
+  let i = 0;
+
+  someUnrelatedCall();
+  ```
+
+- [5.9](#5.9) <a name="5.9"></a> Assign variables at the point that you actually need them; that is, variables need not all be declared at the top of a given scope.
+
+  ```js
+  // bad
+  function checkName(hasName) {
+    const name = getName(); // unnecessary function call if `hasName` is `false`
+    if (!hasName) { return false; }
+    return name.length > 0;
+  }
+
+  // good
+  function checkName(hasName) {
+    if (!hasName) { return false; }
+    const name = getName();
+    return name.length > 0;
+  }
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Control flow
+
+- [6.1](#6.1) <a name="6.1"></a> Never allow fallthrough in `switch` statements.
+
+  ESLint rule: [`no-fallthrough`](http://eslint.org/docs/rules/no-fallthrough.html)
+
+  ```js
+  // bad
+  switch (badVar) {
+  case 1:
+    doSomething();
+  case 2:
+    doSomethingElse();
+  }
+
+  // good
+  switch (goodVar) {
+  case 1:
+    doSomething();
+    break;
+  case 2:
+    doSomethingElse();
+    break;
+  }
+  ```
+
+- [6.2](#6.2) <a name="6.2"></a> Never use labels or the `with` statement.
+
+  ESLint rules: [`no-labels`](http://eslint.org/docs/rules/no-labels.html), [`no-with`](http://eslint.org/docs/rules/no-with.html)
+
+  > Why? Using labels is generally indicative of code that is overly complex. The `with` statement makes it [difficuly for the reader](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Statements/with) to determine whether a given binding exists and, if it exists, in which scope or object it will be found. It is also not allowed in strict mode.
+
+- [6.3](#6.3) <a name="6.3"></a> Never perform assignment in a condition.
+
+  > Why? It can easily create confusion as to whether this was intended or was meant to be a comparison operation.
+
+  ESLint rule: [`no-cond-assign`](http://eslint.org/docs/rules/no-cond-assign.html)
+
+  ```js
+
+  // bad (did you mean `==`/ `===`?)
+  let myVar;
+  if (myVar = doSomething()) {}
+
+  // good
+  const myVar = doSomething();
+  if (myVar) {}
+  ```
+
+- [6.4](#6.4) <a name="6.4"></a> Never have only a single `if` block within an `else` block; combine these into an `else if` block (or, if returning in the `if` block, as another `if` block).
+
+  ESLint rule: [`no-lonely-if`](http://eslint.org/docs/rules/no-lonely-if.html)
+
+  ```js
+  // bad
+  if (conditionOne) {
+    return 'Matched One!';
+  } else {
+    if (conditionTwo) {
+      return 'Matched Two!';
+    }
+  }
+
+  // better
+  if (conditionOne) {
+    return 'Matched One!';
+  } else if (conditionTwo) {
+    return 'Matched Two!';
+  }
+
+  // best
+  if (conditionOne) {
+    return 'Matched One!';
+  }
+
+  if (conditionTwo) {
+    return 'Matched Two!';
+  }
+  ```
+
+- [6.5](#6.5) <a name="6.5"></a> Never nest ternary expressions. When such a complex calculation exists, it is usually best to break it into steps or to use a helper function to calculate the value.
+
+  > Why? They produce incredibly hard to read code.
+
+  ESLint rule: [`no-nested-ternary`](http://eslint.org/docs/rules/no-nested-ternary.html)
+
+  ```js
+  // bad
+  const bad = someCondition ? (someOtherCondition ? 'foo' : 'bar') : (someFinalCondition ? 'baz' : 'qux');
+
+  // good
+  function calculateGood(someCondition, someOtherCondition, someFinalCondition) {
+    if (someCondition) {
+      return someOtherCondition ? 'foo' : 'bar';
+    } else {
+      return someFinalCondition ? 'baz' : 'qux';
+    }
+  }
+
+  const good = calculateGood(someCondition, someOtherCondition, someFinalCondition);
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Objects
+
+- [7.1](#7.1) <a name="7.1"></a> Use object literal syntax for object creation. Use `Object.create` in order to define objects with more complex property descriptors, or to set the object’s prototype.
+
+  ESLint rule: [`no-new-object`](http://eslint.org/docs/rules/no-new-object.html).
+
+  ```javascript
+  // bad
+  const badOne = new Object();
+
+  const badTwo = {};
+  Object.setPrototypeOf(badTwo, badOne);
+
+  const badThree = {};
+  Object.defineProperty(badThree, 'prop', {value: 10, enumerable: false});
+
+  // good
+  const goodOne = {};
+  const goodTwo = Object.create(goodOne);
+  const goodThree = Object.create({}, {
+    value: 10,
+    enumerable: false,
+  });
+  ```
+
+- [7.2](#7.2) <a name="7.2"></a> Never include spaces before the colon in an object literal property declaration. Use one space after the colon or, if it improves readability to align values, indent the fewest number of spaces *after* the colon to align the values.
+
+  ```javascript
+  // bad
+  const badOne = {
+    foo : 1,
+    bar:   2,
+  };
+
+  const badTwo = {
+    short        : 3,
+    longProperty : 4,
+  };
+
+  // good
+  const goodOne = {
+    foo: 1,
+    bar: 2,
+  };
+
+  const goodTwo = {
+    short:        3,
+    longProperty: 4,
+  };
+  ```
+
+- [7.3](#7.3) <a name="7.3"></a> Objects that span multiple lines should have one property per line with each property indented by one level. The closing brace should be on its own line, aligned with the column of the line on which the opening brace appeared.
+
+  ESLint rule: [`indent`](http://eslint.org/docs/rules/indent.html)
+
+  ```javascript
+  // bad
+  const badOne = {
+    foo: 1, bar: 2,
+  };
+
+  const badTwo = {
+      baz: 3, }
+
+  // good
+
+  const goodOne = {
+    foo: 1,
+    bar: 2,
+  };
+
+  const goodTwo = {
+    baz: 3,
+  };
+  ```
+
+- [7.4](#7.4) <a name="7.4"></a> Single-line object literals are permissible, but beware objects with more than a few, short keys: they can quickly become unreadable. Object literals on a single line should not have any spaces after the opening brace or before the closing brace.
+
+  > Why? Objects on a single line use no interior spaces to differentiate them from functions (particular arrow functions) on a single line (which *should* have interior spaces between braces, if present).
+
+  ESLint rules: [`object-curly-spacing`](http://eslint.org/docs/rules/object-curly-spacing.html), [`brace-style`](http://eslint.org/docs/rules/brace-style.html)
+
+  ```javascript
+  // bad
+  const badOne = { foo: 1 };
+  const badTwo = {bar: 2, baz: 3, qux: 4, manyMoreKeys: 5, evenMoreNowItGetsHardToRead: 6};
+
+  // good
+  const goodOne = {foo: 1};
+  const goodTwo = {
+    bar: 2,
+    baz: 3,
+    qux: 4,
+    manyMoreKeys: 5,
+    evenMoreNowItGetsHardToRead: 6,
+  };
+  ```
+
+- [7.5](#7.5) <a name="7.5"></a> Use object method and property shorthands.
+
+  > Why? It is shorter and removes visual noise for objects with many properties and methods.
+
+  ESLint rule: [`object-shorthand`](http://eslint.org/docs/rules/object-shorthand.html)
+
+  ```javascript
+  const name = 'Fido';
+
+  // bad
+  const bad = {
+    name: name,
+    action: function() {
+      return 'bite';
+    },
+  }
+
+  // good
+  const good = {
+    name,
+    action() {
+      return "bark";
+    },
+  };
+  ```
+
+- [7.6](#7.6) <a name="7.6"></a> Use computed property names (unless using Flow, which does not yet support these yet).
+
+  > Why? It allows you to define all properties in one place, and mirrors the way you would access those properties.
+
+  ```javascript
+  const propertyName = 'foo';
+
+  // bad
+  const bad = {};
+  bad[propertyName] = true;
+
+  // good
+  const good = {
+    [propertyName]: true,
+  };
+  ```
+
+- [7.7](#7.7) <a name="7.7"></a> Use dot notation when possible. Use subscript notations (`[]`) only when your key is not a valid identifier or the key is stored in a variable.
+
+  ```js
+  const obj = {fooBar: 1, 'baz-qux': 2};
+
+  // bad
+  const fooBar = obj['fooBar'];
+
+  // good
+  const fooBar = obj.fooBar;
+  const bazQux = obj['baz-qux'];
+
+  const bazKey = 'baz-qux'
+  const altBazQux = obj[bazKey];
+  ```
+
+- [7.8](#7.8) <a name="7.8"></a> When using object literals, place computed properties first, non-function properties second, and function properties third.
+
+  > Why? It’s easier to see which properties are using shorthand, and will generally result in increasing line length of property declarations (which is easier to scan than random line lengths).
+
+  ```javascript
+  const propertyOne = 1;
+  function propertyTwo() {};
+
+  // bad
+  const bad = {
+    doSomethingWithProperties() {},
+    propertyOne,
+    propertyThree: 3,
+    propertyTwo,
+  };
+
+  // good
+  const good = {
+    propertyOne,
+    propertyTwo,
+    propertyThree: 3,
+    doSomethingWithProperties() {},
+  }
+  ```
+
+- [7.9](#7.9) <a name="7.9"></a> Only quote properties that are invalid identifiers.
+
+  > Why? It’s easier to read properties, matches well to how we encourage Ruby hashes with symbols to be written, and encourages you use camelCased, valid identifiers.
+
+  ESLint rule: [`quote-props`](http://eslint.org/docs/rules/quote-props.html)
+
+  ```javascript
+  // bad
+  const bad = {
+    'foo': 1,
+    'bar': 2,
+    'some-invalid-identifier': 3,
+  };
+
+  // good
+  const good = {
+    foo: 1,
+    bar: 2,
+    'some-invalid-identifier': 3,
+  };
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Arrays
+
+- [8.1](#8.1) <a name="8.1"></a> Always use literal syntax for array creation.
+
+  ESLint rule: [`no-array-constructor`](http://eslint.org/docs/rules/no-array-constructor.html)
+
+  ```javascript
+  // bad
+  const bad = new Array();
+
+  // good
+  const good = [];
+  ```
+
+- [8.2](#8.2) <a name="8.2"></a> Do not insert spaces on the inside of array literals on a single line. Indent every item of an array literal that spans multiple lines by two spaces, and align the closing bracket to the column of the line that contains the opening bracket. If your array spans multiple lines, place only one item per line.
+
+  > Why? These stylistic choices make array and object literal declarations visually consistent with one another.
+
+  ESLint rule: [`array-bracket-spacing`](http://eslint.org/docs/rules/array-bracket-spacing.html)
+
+  ```javascript
+  // bad
+  const badOne = [ 1, 2 ];
+  const badTwo = [
+    3,
+    4, 5,
+    ]
+
+  // good
+  const goodOne = [1, 2];
+  const goodTwo = [
+    3,
+    4,
+    5,
+  ];
+  ```
+
+- [8.3](#8.3) <a name="8.3"></a> Use `Array#push` instead of direct assignment to add items to an array.
+
+  ```javascript
+  const myArray = [];
+
+  // bad
+  myArray[myArray.length] = 'bad';
+
+  // good
+  myArray.push('good');
+  ```
+
+- [8.4](#8.4) <a name="8.4"></a> Use the spread operator (`...`) to copy arrays, rather than iterating over the array or using `Array#slice`. If you need subsections of the array, continue to use `Array#slice`.
+
+  ```javascript
+  const originalArray = [1, 2, 3];
+
+  // bad
+  const badNewArray = [];
+  originalArray.forEach((item) => badNewArray.push(item));
+  const otherBadNewArray = originalArray.slice();
+
+  // good
+  const goodNewArray = [...originalArray];
+  ```
+
+- [8.5](#8.5) <a name="8.5"></a> To convert from an array-like object to an array (for example, a `NodeList` returned by `document.querySelectorAll`, or a jQuery object), use `Array.from`.
+
+  ```javascript
+  const nodes = document.querySelectorAll('.my-nodes');
+
+  // bad
+  const badNodesArray = [].slice.apply(nodes);
+
+  // good
+  const goodNodesArray = Array.from(nodes);
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Strings
+
+- [9.1](#9.1) <a name="9.1"></a> Use single quotes for strings. Using double quotes is acceptable only to avoid escaping contained single quotes.
+
+  > Why? We don’t want to argue about this. Like, ever. Please use single quotes!
+
+  ESLint rule: [`quotes`](http://eslint.org/docs/rules/quotes.html)
+
+  ```javascript
+  // bad
+  const badOne = "Sorry not sorry";
+  const badTwo = `No interpolation, no need`;
+  const badThree = 'Escaping is \'no good\'';
+
+  // good
+  const goodOne = 'Nice and clean';
+  const goodTwo = 'No interpolation, no backticks';
+  const goodThree = "Double quotes are 'fine' in this case.";
+  ```
+
+- [9.2](#9.2) <a name="9.2"></a> Avoid long strings if possible. If you must include a long string, you can include multiline strings in code using backticks (`` ` ``). If the whitespace of multiline strings is unacceptable, you can use multiline string concatenation or an array of reasonable-length strings joined together.
+
+  ```javascript
+  // bad
+  const badString = 'The path of the righteous man is beset on all sides by the iniquities of the selfish and the tyranny of evil men. Blessed is he who, in the name of charity and good will, shepherds the weak through the valley of darkness'
+
+  // fine, if newlines are acceptable
+  const fineString = `
+    The path of the righteous man is beset on all sides by the iniquities of the selfish and the tyranny of evil men.
+    Blessed is he who, in the name of charity and good will, shepherds the weak through the valley of darkness
+  `;
+
+  // good
+  const goodString = 'The path of the righteous man is beset on all sides ' +
+    'by the iniquities of the selfish and the tyranny of evil men. ' +
+    'Blessed is he who, in the name of charity and good will, ' +
+    'shepherds the weak through the valley of darkness';
+  ```
+
+- [9.3](#9.3) <a name="9.3"></a> Use template strings instead of concatenation.
+
+  > Why? The template string syntax is easier to read and consistent with how we build strings programatically in other languages.
+
+  ESLint rule: [`prefer-template`](http://eslint.org/docs/rules/prefer-template.html)
+
+  ```javascript
+  const name = 'Chris';
+
+  // bad
+  const badOne = 'DO NOT do it this way, ' + name + '!';
+  const badTwo = ['And definitely not this way, either, ', name, '!'].join('');
+
+  // good
+  const goodOne = `Much better, ${name}!`;
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Functions
+
+- [10.1](#10.1) <a name="10.1"></a> Never use the Function constructor to create a new function. Similarly, never use `eval`.
+
+  > Why? Creating a function in this way evaluates the string as-is, allowing for vulnerabilities and making code harder to test.
+
+  ESLint rules: [`no-new-func`](http://eslint.org/docs/rules/no-new-func.html), [`no-eval`](http://eslint.org/docs/rules/no-eval.html), [`no-implied-eval`](http://eslint.org/docs/rules/no-implied-eval.html)
+
+  ```js
+  // bad
+  const add = new Function('a', 'b', 'return a + b');
+  ```
+
+- [10.2](#10.2) <a name="10.2"></a> Use function declarations instead of function expressions.
+
+  > Why? Function declarations are named, so they’re easier to identify in call stacks. Also, the whole body of a function declaration is hoisted, whereas only the reference of a function expression is hoisted. This rule makes it possible to always use Arrow Functions in place of function expressions.
+
+  ESLint rule: [`func-style`](http://eslint.org/docs/rules/func-style.html)
+
+  ```js
+  // bad
+  const bad = function() {}
+
+  // good
+  function good() {}
+  ```
+
+- [10.3](#10.3) <a name="10.3"></a> When using IIFEs, always wrap the function parentheses, with dangling parentheses for the function call.
+
+  > **Note**: If using modules, the module (file) itself serves as a private scope for variables. As such, IIFEs are rarely needed in this case. Additionally, when using `const`/ `let`, you can create a private scope simply by using an unnamed block.
+
+  ESLint rule: [`wrap-iife`](http://eslint.org/docs/rules/wrap-iife.html)
+
+  ```js
+  // bad
+  ;function() {
+    const privateMember = 'foo';
+  }()
+
+  (function() {
+    const privateMember = 'foo';
+  }())
+
+  // good
+  (function() {
+    const privateMember = 'foo';
+  })()
+  ```
+
+- [10.4](#10.4) <a name="10.4"></a> Anonymous functions leave no space between the `function` keyword and the parentheses. All functions have no spaces around their list of parameters, and a single space between the closing paren of the parameter list and the opening curly brace.
+
+  > Why? Because consistency is good!
+
+  ESLint rules: [`space-before-blocks`](http://eslint.org/docs/rules/space-before-blocks.html), [`space-before-function-paren`](http://eslint.org/docs/rules/space-before-function-paren.html), [`space-in-parens`](http://eslint.org/docs/rules/space-in-parens.html)
+
+  ```js
+  // bad
+  function badOne(){}
+  function badTwo () {}
+  function badThree( arg1, arg2 ) {}
+
+  // good
+  function goodOne() {}
+  function goodTwo() {}
+  function goodThree(arg1, arg2) {}
+  ```
+
+- [10.5](#10.5) <a name="10.5"></a> Never declare a function in a non-function block (`if`, `while`, etc). Assign the function to a variable instead.
+
+  > Why? ECMA-262 defines a `block` as a list of statements. A function declaration is not a statement. As such, declaring a function in a block is not spec-compliant, and can be interpreted differently depending on the environment.
+
+  ESLint rule: [`no-loop-func`](http://eslint.org/docs/rules/no-loop-func.html)
+
+  ```js
+  // bad
+  if (true) {
+    function bad() {
+      console.log('Please avoid this!');
+    }
+  }
+
+  // good
+  let test;
+  if (true) {
+    test = () => console.log('This is better!');
+  }
+  ```
+
+- [10.6](#10.6) <a name="10.6"></a> Functions should either always return a value, or never return a value. If a function optionally returns something, return `null` in the case where the relevant conditions were not met.
+
+  ESLint rule: [`consistent-return`](http://eslint.org/docs/rules/consistent-return.html)
+
+  ```js
+  // bad
+  function badFunction(condition) {
+    if (!condition) { return; }
+    return 'Condition met!';
+  }
+
+  // good
+  function goodFunction(condition) {
+    if (!condition) { return null; }
+    return 'Condition met!';
+  }
+  ```
+
+- [10.7](#10.7) <a name="10.7"></a> Instead of using `function#apply()` to call a function with an array of arguments, use the spread operator.
+
+  > Why? It reduces redundancy since you don’t have to specify the object to apply against, and it mirrors the rest syntax when declaring variadic functions.
+
+  ESLint rule: [`prefer-spread`](http://eslint.org/docs/rules/prefer-spread.html)
+
+  ```js
+  const numbers = [1, 2, 3, 4, 5];
+
+  // bad
+  const max = Math.max.apply(Math, numbers);
+
+  // good
+  const max = Math.max(...numbers);
+  ```
+
+### Arrow Functions
+
+- [10.8](#10.8) <a name="10.8"></a> When you must use a function expression (for example, as an anonymous function in a callback), use arrow function notation.
+
+  > Why? The function will execute without binding `this`, so it can use the `this` of its defining scope, which is usually what you want. It is also a more concise syntax, particularly for chained methods that take callbacks.
+
+  ESLint rule: [`prefer-arrow-callback`](http://eslint.org/docs/rules/prefer-arrow-callback.html)
+
+  ```js
+  function takesCallback(callback) {
+    callback();
+  }
+
+  // bad
+  takesCallback(function() {
+    console.log('This is no good!');
+  });
+
+
+  // good
+  takesCallback(() => {
+    console.log('Much better!');
+  });
+  ```
+
+- [10.9](#10.9) <a name="10.9"></a> Always leave one space on either side of the arrow.
+
+  ESLint rule: [`arrow-spacing`](http://eslint.org/docs/rules/arrow-spacing.html)
+
+  ```js
+  // bad
+  (bad)=>{}
+  (bad)=> {}
+  (bad) =>{}
+  (bad) =>'terrible'
+
+  // good
+  (good) => {}
+  (good) => 'fabulous'
+  ```
+
+- [10.1](#10.1) <a name="10.1"></a> If the body of your arrow function takes only a single expression, omit the braces and make use of the implicit `return`. If you are returning an object, however, you must use braces and an explicit `return`.
+
+  > Why? It reads better when multiple such functions are chained together.
+
+  ESLint rule: [`arrow-body-style`](http://eslint.org/docs/rules/arrow-body-style.html)
+
+  ```js
+  // bad
+  [1, 2, 3]
+    .map((x) => {
+      return (x * x) + 1;
+    })
+    .filter((x) => {
+      return x < 6;
+    });
+
+  // doesn't return an object with `foo` key, actually returns nothing!
+  runCallback((foo) => {foo});
+
+  // good
+  [1, 2, 3]
+    .map((x) => (x * x) + 1)
+    .filter((x) => x < 6);
+
+  runCallback((foo) => {
+    return {foo};
+  });
+  ```
+
+- [10.11](#10.11) <a name="10.11"></a> Always include parentheses around the arguments of an arrow function.
+
+  > Why? Even though you can omit the parentheses around an arrow function with a single argument, it is better to maintain consistency with the zero-argument and multiple-argument cases for arrow functions, which require parentheses.
+
+  ESLint rule: [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens.html)
+
+  ```js
+  // bad
+  [1, 2, 3].map(x => x * x);
+
+  // good
+  [1, 2, 3].map((x) => x * x);
+  ```
+
+### Parameters
+
+- [10.12](#10.12) <a name="10.12"></a> Never use the implicitly defined `arguments` array-like object provided by functions. Instead, use rest syntax (`...`) to describe variadic arguments.
+
+  > Why? `...` is explicit in which arguments you want pulled, and covers the boilerplate of assigning parameters out of `arguments`. It also provides an actual array, so all array prototype methods are available.
+
+  ```js
+  // bad
+  function allThe() {
+    const bads = Array.from(arguments);
+    return bads.map((bad) => `${bad} is bad!`);
+  }
+
+  // good
+  function allThe(...goods) {
+    return goods.map((good) => `${good} is good!`);
+  }
+  ```
+
+- [10.13](#10.13) <a name="10.13"></a> Use default arguments rather than mutating function arguments.
+
+  > Why? The syntax makes it clear what you are trying to do, and you avoid the subtle bugs that can be introduced by checking whether a parameter was provided.
+
+  ```js
+  // bad
+  function badOne(options) {
+    {}; // might not be what you want for falsey `options`
+  }
+
+  function badTwo(options) {
+    options = (options == null) ? {} : options;
+  }
+
+  // good
+  function good(options = {}) {}
+  ```
+
+- [10.14](#10.14) <a name="10.14"></a> Avoid side effects or complex default parameters.
+
+  > Why? They can be difficult to reason about and typically indicate that your function is doing too much.
+
+  ```js
+  let a = 1;
+
+  // bad
+  function badOne(b = a++) {}
+  function badTwo(arg = [1, 2, 3].map((val) => val * 3)) {}
+
+  // good
+  function goodOne(b) {}
+  goodOne(a++);
+
+  function createDefaultParameter() {}
+  function goodTwo(arg = createDefaultParameter()) {}
+  ```
+
+- [10.15](#10.15) <a name="10.15"></a> Always put default parameters last.
+
+  ```js
+  // bad
+  function bad(options = {}, name) {}
+
+  // good
+  function good(name, options = {}) {}
+  ```
+
+- [10.16](#10.16) <a name="10.16"></a> Be careful not to overcomplicate function declarations using new object parameter-related features. While you can destructure, use the rest operator, provide default parameter values, provide a default argument, and provide different local names for parameters, limit your use of these such that your code remains readable. In general, avoid providing a complex default hash in addition to default parameter values.
+
+  ```js
+  // bad (parameter list is complex to reason about)
+  function bad({
+    foo: myFoo = 2,
+    bar = 10000,
+    ...otherOptions,
+  } = {foo: 'foo', qux: true}) {}
+
+  // good (this is probably the most complex structure that's acceptable)
+  function good({foo = 2, bar = 10000, ...otherOptions} = {}) {}
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Types and casting
+
+- [11.1](#11.1) <a name="11.1"></a> Use the `String` function to convert a value to a string.
+
+  ESLint rules: [`no-implicit-coercion`](http://eslint.org/docs/rules/no-implicit-coercion.html), [`no-new-wrappers`](http://eslint.org/docs/rules/no-new-wrappers.html)
+
+  ```js
+  const number = 15;
+
+  // bad
+  const badStringNumOne = number + '';
+  const badStringNumTwo = new String(number);
+
+  // good
+  const goodStringNum = String(number);
+  ```
+
+- [11.2](#11.2) <a name="11.2"></a> Use the `Number` function for type casting and `Number.parseInt` for parsing strings. Always include the radix parameter when using `Number.parseInt`.
+
+  > Why? Forgetting to include the radix when your string starts with `0` or `0x` will result in it being parsed as an octal or hexadecimal number, respectively (which is not usually what you want). Providing a radix forces you to specify the way in which the string is parsed.
+
+  ESLint rules: [`radix`](http://eslint.org/docs/rules/radix.html), [`no-implicit-coercion`](http://eslint.org/docs/rules/no-implicit-coercion.html), [`no-new-wrappers`](http://eslint.org/docs/rules/no-new-wrappers.html)
+
+  ```js
+  const input = '43';
+
+  // bad
+  const badOne = new Number(input);
+  const badTwo = +input;
+  const badThree = input >> 0;
+  const badFour = Number.parseInt(input);
+  const badFive = parseInt(input);
+
+  // good
+  const goodOne = Number(input);
+  const goodTwo = Number.parseInt(input, 10);
+  ```
+
+- [11.3](#11.3) <a name="11.3"></a> Use the `Boolean` function for casting to a boolean value (or the relevant comparison operators, where possible). Never use double negation (`!!`), the `Boolean` constructor, or other “clever” techniques for getting a boolean value.
+
+  ESLint rules: [`no-implicit-coercion`](http://eslint.org/docs/rules/no-implicit-coercion.html), [`no-new-wrappers`](http://eslint.org/docs/rules/no-new-wrappers.html), [`no-extra-boolean-cast`](http://eslint.org/docs/rules/no-extra-boolean-cast.html)
+
+  ```js
+  const collection = [];
+
+  // bad
+  const badOne = !!collection;
+  const badTwo = new Boolean(collection);
+  const badThree = ~collection.indexOf('foo');
+
+  // good
+  const goodOne = Boolean(collection);
+  const goodTwo = collection.indexOf('foo') >= 0
+  ```
+
+- [11.4](#11.4) <a name="11.4"></a> Use `===` and `!==` over `==` and `!=`. The only exception to this rule is `== null`, which is allowed in order to check whether a reference is either `null` or `undefined`.
+
+  > Why? `==` and `!=` perform type coercion, which can result in some unexpected comparions (for example, `[] == false` and `3 == '03'` evaluate to `true`). `===` and `!==` test for strict equality, which is almost always what you want.
+
+  ESLint rule: [`eqeqeq`](http://eslint.org/docs/rules/eqeqeq.html)
+
+  ```js
+  // bad
+  if (badValue == 3) {}
+
+  // good
+  if (goodValue === 3) {}
+  ```
+
+- [11.5](#11.5) <a name="11.5"></a> Don’t use shorthand boolean comparisons.
+
+  > **Note**: remember that `false`, `undefined`, `null`, `''`, `0`, and `NaN` evaluate to `false`, and all other values evaluate to `true`.
+
+  > Why? Using the shorthands relies on JavaScript’s questionable cooercion rules, which allow more values than you might expect to be treated as `false`. Using the explicit boolean check makes your code clearer to future readers.
+
+  ```js
+  const name = '';
+  const collection = [];
+
+  // bad
+  if (name) {}
+  if (collection.length) {}
+
+  // good
+  if (name !== '') {}
+  if (name.length !== 0) {}
+  if (collection.length > 0) {}
+  ```
+
+- [11.6](#11.6) <a name="11.6"></a> Use the following patterns for type checking:
+
+  ```js
+  // String
+  typeof something === 'string';
+
+  // Number
+  typeof something === 'number';
+
+  // Boolean
+  typeof something === 'boolean';
+
+  // Object
+  something != null && typeof something === 'object';
+
+  // Array
+  Array.isArray(something);
+
+  // Null
+  something === null;
+
+  // Undefined
+  something === undefined;
+
+  // Null or Undefined
+  something == null;
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## ES2015 Features
+
+- [12.1](#12.1) <a name="12.1"></a> When using features that are not natively supported in some target environments (typically, browsers), use [`core-js`](https://github.com/zloirock/core-js) to provide polyfills. **Do not** include the entire `core-js` shim; `core-js` is extremely modular and allows you to be selective of what polyfills you want to include based on the features you need and your [target environments' feature support](https://kangax.github.io/compat-table/es6/).
+
+- [12.2](#12.2) <a name="12.2"></a> Limit use of generators and proxies, as these don’t transpile well (or at all) to ES5.
+
+### Destructuring
+
+- [12.3](#12.3) <a name="12.3"></a> Use object destructuring to retrieve multiple properties from an object.
+
+  > Why? Destructuring removes a lot of boilerplate and encourages you to refer to properties by the same name everywhere they are referenced.
+
+  ```js
+  // bad
+  function fullNameForUser(user) {
+    const firstName = user.firstName;
+    const lastName = user.lastName;
+
+    return `${firstName} ${lastName}`;
+  }
+
+  // good
+  function fullNameForUser(user) {
+    const {firstName, lastName} = user;
+    return `${firstName} ${lastName}`;
+  }
+
+  // best
+  function fullNameForUser({firstName, lastName}) {
+    return `${firstName} ${lastName}`;
+  }
+  ```
+
+- [12.4](#12.4) <a name="12.4"></a> Use array destructuring rather than manually accessing items by their index. If your array has more than a few entries, and you are selecting only a small number of them, continue to use index notation.
+
+  ```js
+  const array = [1, 2];
+  const longArray = [1, 2, 3, 4, 5];
+
+  // bad
+  const first = array[0];
+  const second = array[1];
+
+  const [secondLong,,,, fifthLong] = longArray;
+
+  // good
+  const [first, second] = array;
+
+  const secondLong = longArray[1];
+  const fifthLong = longArray[4];
+  ```
+
+- [12.5](#12.5) <a name="12.5"></a> If you need to return multiple values from a function, return them using an object rather than an array.
+
+  > Why? Call sites that use destructuring to access your return values need to care about the ordering when returning an array, making them fragile to change.
+
+  ```js
+  // bad
+  function positionForNode(node) {
+    // figure stuff out
+    return [left, right, top, bottom];
+  }
+
+  const [left, _, top] = positionForNode(node);
+
+  // good
+  function positionForNode(node) {
+    // figure stuff out
+    return {left, right, top, bottom};
+  }
+
+  const {left, top} = positionForNode(node);
+  ```
+
+- [12.6](#12.6) <a name="12.6"></a> You can create highly readable functions by using one positional argument, followed by a destructured object. You can even provide different local names for the destructured arguments to have both an expressive external API and concise internal references.
+
+  ```js
+  // fine, but too many positional arguments, so it's hard for call sites to know what to do
+  function horizontalPosition(node, container, offset) {
+    return container.offsetLeft + node.offsetLeft + offset.left;
+  }
+
+  horizontalPosition(node, node.parentNode, offset);
+
+  // good: arguments are explicit
+  function horizontalPositionForNode(node, {inContainer, withOffset}) {
+    return inContainer.offsetLeft + node.offsetLeft + withOffset.left;
+  }
+
+  horizontalPositionForNode(node, {inContainer: node.parentNode, withOffset: offset});
+
+  // also good: more concise internal names, same external API
+  function horizontalPositionForNode(node, {inContainer: container, withOffset: offset}) {
+    return container.offsetLeft + node.offsetLeft + offset.left;
+  }
+
+  horizontalPositionForNode(node, {inContainer: node.parentNode, withOffset: offset});
+  ```
+
+### Classes
+
+- [12.7](#12.7) <a name="12.7"></a> Use classes with care: they do not behave in exactly the way you would expect in other languages, and JavaScript provides many mechanisms (closures, simple objects, etc) that solve problems for which you might use a class in another language. The rule of thumb is: use the right tool for the job!
+
+  ```js
+  // bad
+  // all static members, no need for a class
+  class BadSingleton {
+    static singletonProp = 'foo';
+    static singletonMethod() {
+      return 'bar';
+    }
+  }
+
+  // good
+  const GoodSingleton = {
+    singletonProp: 'foo',
+    singletonMethod() {
+      return 'bar';
+    },
+  };
+
+  // bad
+  // needlessly using a class to encapsulate data that could be passed to a function
+  class BadChoice {
+    constructor(first, second) {
+      this.first = fires;
+      this.second = second;
+    }
+
+    takeAction() {
+      return `The first: ${this.first}, the second: ${this.second}`;
+    }
+  }
+
+  const result = new BadChoice('foo', 'bar').takeAction();
+
+  // good
+  function takeAction({first, second}) {
+    return `The first: ${first}, the second: ${second}`;
+  }
+
+  const result = takeAction({first: 'foo', second: 'bar'});
+  ```
+
+- [12.8](#12.8) <a name="12.8"></a> If you want to use constructor functions, use `class` syntax. Avoid creating them by manually updating the prototype.
+
+  > Why? `class` syntax is more concise and will be more familiar for developers trained in other languages.
+
+  ```js
+  // bad
+  function BadClass() {
+    this.isNotIdeal = true;
+  }
+
+  BadClass.prototype.shouldIDoThis = function() {
+    return 'Definitely not';
+  }
+
+  // good
+  class GoodClass {
+    constructor() {
+      this.isIdeal = true;
+    }
+
+    shouldIDoThis() {
+      return 'Yes!';
+    }
+  }
+  ```
+
+- [12.9](#12.9) <a name="12.9"></a> If you are subclassing, your subclass’s constructor should always call `super` before referencing `this`.
+
+  > Why? If your forget to call `super` in your subclass constructor, your object will be uninitialized and calling `this` will result in an exception.
+
+  ESLint rule: [`no-this-before-super`](http://eslint.org/docs/rules/no-this-before-super.html)
+
+  ```js
+  class Base {}
+
+  // bad
+  class BadClass extends Base {
+    constructor() {
+      this.bad = true;
+      super('I am bad :(');
+    }
+  }
+
+  // good
+  class GoodClass extends Base {
+    constructor() {
+      super('I am good :)');
+      this.good = true;
+    }
+  }
+  ```
+
+- [12.1](#12.1) <a name="12.1"></a> When declaring static members or properties, prefer the `static` keyword to direct assignment to the class object. Put `static` members at the top of your class definition.
+
+  > Why? Using the `static` keyword is more expressive and keeps the entire class definition in one place.
+
+  ```js
+  // bad
+  class BadClass {
+    constructor() {}
+    instanceMethod() {}
+  }
+
+  BadClass.staticProperty = 'foo';
+  BadClass.staticMethod = function() {}
+
+  // good
+  class GoodClass {
+    static staticProperty = 'foo';
+    static staticMethod() {}
+
+    constructor() {}
+    instanceMethod() {}
+  }
+  ```
+
+### Modules
+
+- [12.11](#12.11) <a name="12.11"></a> Always use modules (`import`/ `export`) over a non-standard module system (CommonJS being the most popular of these).
+
+  > Why? Modules are the future, so let’s get a head start. You can always transpile to a preferred module system.
+
+  ```js
+  // bad
+  const BadImport = require('./BadImport');
+  module.exports = BadImport.feelBadAboutIt();
+
+  // good
+  import {feelGoodAboutIt} from './GoodImport';
+  export default feelGoodAboutIt();
+  ```
+
+- [12.12](#12.12) <a name="12.12"></a> Avoid complex relative import paths. It is usually fairly easy and much clearer to add the root of your project to the load path.
+
+  > Why? Relative paths are fragile and hard to parse for humans.
+
+  ```js
+  // bad
+  export feelBadAboutIt from '../../../lib/BadImport';
+
+  // good (with some path additions)
+  import feelGoodAboutIt from 'lib/GoodImport';
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Resources
+
+### Tools
+
+- [ES6 Compatibility Table](https://kangax.github.io/compat-table/es6/) (shows browser, platform, and transpiler ES2015+ feature support)
+- [ES6 Katas](http://es6katas.org) (learn ES6 by fixing tests)
+- Editor Linting Plugins
+  - [SublimeLinter-eslint](https://github.com/roadhump/SublimeLinter-eslint)
+  - [linter-eslint for Atom](https://atom.io/packages/linter-eslint)
+  - [ESLint for IntelliJ IDEs](http://plugins.jetbrains.com/plugin/7494)
+
+### Books
+
+- [JavaScript: The Good Parts](http://www.amazon.com/JavaScript-Good-Parts-Douglas-Crockford/dp/0596517742) by Douglas Crockford
+- [You Don’t Know JS Book Series](https://github.com/getify/You-Dont-Know-JS) by Kyle Simpson
+- [Eloquent JavaScript](http://eloquentjavascript.net) by Marijn Haverbeke
+- [Exploring ES6](http://exploringjs.com) by Dr. Axel Rauschmayer
+
+### Blogs
+
+- [JavaScript Weekly](http://javascriptweekly.com/)
+- [Addy Osmani](https://addyosmani.com/blog/)
+- [Pony Foo](https://ponyfoo.com)
+- [2ality](http://www.2ality.com)
+- [Getify](http://blog.getify.com)
+- [Rebecca Murphy](http://rmurphey.com)
+
+### Podcasts
+
+- [Javascript Air](http://audio.javascriptair.com)
+- [JavaScript Jabber](https://devchat.tv/js-jabber/)
+
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)

--- a/jquery/README.md
+++ b/jquery/README.md
@@ -1,0 +1,83 @@
+# `import {jQuery} from 'Shopify'`
+
+This guide provides a few guidelines on writing sensible jQuery.
+
+## Rules
+
+- When starting a new project, make sure you really need jQuery before including it. DOM APIs have improved significantly, and most jQuery operations have [easy-to-use equivalents](http://youmightnotneedjquery.com) that avoid the need for a large library.
+
+- Prefix all jQuery references with a `$`.
+
+  > Why? This allows another developer to easily identify a jQuery variable (in particular, to differentiate such an object from a vanilla DOM node).
+
+  ```js
+  // bad
+  let sidebar = $('.sidebar');
+  this.node = $(node);
+
+  // good
+  let $sidebar = $('.sidebar');
+  this.$node = $(node);
+  ```
+
+- Cache jQuery lookups whenever you will use more than once. If possible, use jQuery’s excellent support for chaining to avoid having to store any local references.
+
+  ```js
+  // bad
+  $('.sidebar').attr('aria-hidden', true);
+  $('.sidebar').css({opacity: 0});
+
+  // better
+  let $sidebar = $('.sidebar');
+  $sidebar.attr('aria-hidden', true);
+  $sidebar.css({opacity: 0});
+
+  // best
+  $('.sidebar')
+    .attr('aria-hidden', true)
+    .css({opacity: 0});
+  ```
+
+- All CSS updates that do not have to be calculated dynamically should be applied by a CSS selector that is toggled by JavaScript (as opposed to manually setting the style in JavaScript).
+
+  > Why? This allows all styling information to live in a single place (CSS), and simplifies testing. It also makes it easier to reverse styles, as you do not need to store the original values and re-apply them.
+
+  ```js
+  // bad
+  $('.ui-banner').css({color: 'rgba(0, 0, 0, 0.8)', backgroundColor: 'orange'});
+
+  // good
+  $('.ui-banner').addClass('ui-banner--warning');
+  ```
+
+- Do not treat `$(document).ready()` (or, equivalently, passing a function to `$()`) as a dumping ground for your entire application. The ready block should be used to initialize your application, with all initialization happening in small, testable, dedicated functions.
+
+- Use `on` for binding events rather than using its aliases.
+
+  ```js
+  // bad
+  $('#BadButton').click(() => {});
+
+  // good
+  $('#GoodButton').on('click', () => {});
+  ```
+
+- When binding multiple callbacks to a jQuery object, use chaining.
+
+  ```js
+  // bad
+  let $document = $(document);
+  $document.on('ready', () => {});
+  $document.on('click', () => {});
+
+  // still bad
+  $(document).on({
+    ready() {},
+    click() {},
+  });
+
+  // good
+  $(document)
+    .on('ready', () => {})
+    .on('click', () => {});
+  ```

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -1,0 +1,795 @@
+# Legacy JavaScript Styleguide
+
+This guide is a snapshot of our "legacy" JavaScript styleguide. Any new projects should use the [newer styleguide](../), but projects that have a lot of existing code can continue to use the guide below. Note that some rules in this guide may conflict with the [shared ESLint configuration](../packages/eslint-config-shopify), as it is configured to match our newer styleguide.
+
+### TL;DR (details and rationale follow below)
+
+#### Whitespace:
+```javascript
+if (condition === 'foo') {
+  // statements
+}
+
+// Note the space before function params. Intended to distinguish between
+// function invocation 'function()' and declaration.
+var fooBar = function () {
+  // statements
+};
+
+_.each(items, function (item, index) {
+  // statements
+});
+
+// Spacing between sibling functions, no newlines immediately inside of function declarations
+describe('foo', function () {
+  describe('bar', function () {
+    it('baz', function () {
+      var foo = 'hello world';
+
+      expect(foo).to.eql(bar);
+    });
+
+    it('baz', function () {
+      var foo = 'hello world';
+      var bar = 'hello world';
+
+      expect(foo).to.eql(bar);
+    });
+  });
+});
+```
+
+#### Variables & Naming:
+Variables should be declared at the top of their scope (function)
+
+```javascript
+// Constructor function:
+var FooBar = function () {};
+
+// Single declaration:
+var fooBar = 'bar';
+
+// Multiple declarations:
+var fooBar = 'bar';
+var barFoo = 'foo';
+var lol = hello;
+var test;
+var ok;
+
+// jQuery object in variable, preface name with $
+var $fooBar = $('.bar');
+
+// Constants
+// used only for rare cases like external dependencies
+var SIGNUP_URL = 'foo';
+
+// events are passed as `evt`
+var clickHandler = function (evt) {
+  evt.preventDefault();
+}
+
+// event namespace uses snake_case
+$('.foo').on('click.foo_click', clickHandler);
+```
+
+#### Callbacks / objects as params
+```javascript
+// When passing a callback, or object as a parameter, open the curly brace on
+// the same line as the function invocation.
+
+var foo = bar(lol, function () {
+  // statements
+});
+
+var foo = bar(lol, {
+  // Object properties
+});
+```
+
+#### Event Binding - `.on` vs aliases
+```javascript
+// Always use jQuery's `.on` syntax for event bindings, rather than its aliased methods, such as `.click` and `.load`.
+
+// BAD:
+$(document).load(function() { ... });
+$('.my-div').click(function() { ... });
+
+// GOOD:
+$(document).on('load', function() { ... });
+$('.my-div').on('click', function() { ... });
+```
+By using the `.on` function, we can not only bind to individual events, but also use namespaced events (i.e. 'click.modal'), use delegated events (i.e. `$('.modal').on('keypress', '.text-input', function() { ... });`), and pass object literals with event/callback pairs:
+```javascript
+$('.text-input').on({
+  click: function() { ... }),
+  keypress: function() { ... })
+});
+```
+
+#### Equality
+```javascript
+// Only use === and !==, never == and !=
+
+if (1 === '1') {
+  // this will never be executed, which is great.
+}
+
+// .. unless the case requires loose type evaluation, see section 4.1.7 below
+
+```
+
+#### Conditionals
+```javascript
+// Always use braces, and line breaks with conditionals to promote readability
+// and put else and else if statements inline with the closing brace
+if (condition) {
+  return true;
+} else if (condition) {
+  return true;
+} else {
+  return false;
+}
+
+```
+
+### Iteration
+```javascript
+// When iterating using a function that makes a node available, use the node
+// rather than `this` to access the node. For naming, use something contextual,
+// or `el`.
+
+// All of these are acceptable
+$('.nodes').each(function(i, node) {
+  console.log(node);
+});
+
+$('.nodes').each(function(i, el) {
+  console.log(el);
+});
+
+_.map($('.nodes'), function (el) {
+  console.log(el);
+})
+```
+
+#### Line length
+Limit line length to 80 chars.
+
+#### Quotes
+Use **single quotes**
+
+### Project Settings
+To facilitate these rules, consider adding the following to your project tests or at least text editor.
+
+* JSHint - https://github.com/Shopify/fed-sandbox/blob/master/code/project-dots/sample.jshintrc
+
+  ```
+  "jshint": {
+    "browser": true,
+    "node": true,
+    "curly": true,
+    "eqeqeq": true,
+    "evil": true,
+    "indent": 2,
+    "quotmark": "single",
+    "regexdash": true,
+    "smarttabs": false,
+    "sub": true,
+    "trailing": true,
+    "undef": true,
+    "wsh": true,
+    "camelcase": true,
+    "predef": [
+      <YOUR GLOBALS>,
+      eg:,
+      "App",
+      "Modernizr"
+    ]
+  }
+
+  ```
+* JSCS - https://github.com/Shopify/fed-sandbox/blob/master/code/project-dots/sample.jscsrc
+
+* Sublime Linters
+  * https://github.com/SublimeLinter/SublimeLinter3
+  * https://sublime.wbond.net/packages/SublimeLinter-jscs
+* Testing Workflow in Brochure 2 - https://github.com/Shopify/brochure2/blob/master/Gruntfile.js#L42
+
+------------------------------------------------
+
+## Details - Why a styleguide and where'd it come from?
+
+This is a living document and new ideas for improving the code around us are always welcome. It is based off [idiomatic.js](https://github.com/rwaldron/idiomatic.js) and simplified for use at Shopify. It came about from the 2014 Brochure redesign where four front end developers were actively writing JS without any standards to tie everything together. It got messy.
+
+The goal is the following:
+
+### All code in any code-base should look like a single person typed it, no matter how many people contributed.
+
+
+> #### "Arguments over style are pointless. There should be a style guide, and you should follow it"
+>_Rebecca_ _Murphey_
+
+&nbsp;
+
+> #### "Part of being a good steward to a successful project is realizing that writing code for yourself is a Bad Idea™. If thousands of people are using your code, then write your code for maximum clarity, not your personal preference of how to get clever within the spec."
+>_Idan_ _Gazit_
+
+### Resources
+
+ * [jshint](http://jshint.com/)
+ * [Annotated ECMAScript 5.1](http://es5.github.com/)
+ * [EcmaScript Language Specification, 5.1 Edition](http://ecma-international.org/ecma-262/5.1/)
+
+## [Preface](https://www.youtube.com/watch?v=0hiUuL5uTKc)
+
+The following sections outline a style guide for modern JavaScript development.
+They are meant to be prescriptive. The most important take-away is the
+**law of code style consistency**. Whatever you choose as the style for your
+project should be considered law. Link to this document as a statement of your
+project's commitment to code style consistency, readability and maintainability.
+
+## Table of Contents
+
+ 1. [Whitespace](#whitespace)
+ 2. [Beautiful Syntax](#spacing)
+ 3. [Type Checking (Courtesy jQuery Core Style Guidelines)](#type)
+ 4. [Conditional Evaluation](#cond)
+ 5. [Naming](#naming)
+ 6. [Comments](#comments)
+ 7. [jQuery](#jquery)
+
+1. <a name="whitespace">Whitespace</a>
+  - Never mix spaces and tabs. Indentation should be 2 spaces.
+  - If your editor supports it, always work with the "show invisibles" setting turned on. The benefits of this practice are:
+    - Enforced consistency
+    - Eliminating end of line whitespace
+    - Eliminating blank line whitespace
+    - Commits and diffs that are easier to read
+
+
+
+2. <a name="spacing">Beautiful Syntax</a>
+
+  A. Parens, Braces, Linebreaks
+
+  ```javascript
+
+  // if/else/for/while/try always have spaces, braces and span multiple lines
+  // this encourages readability
+
+  // 2.A.1.1
+  // Examples of really cramped syntax
+
+  if(condition) doSomething();
+
+  while(condition) iterating++;
+
+  for(var i=0;i<100;i++) someIterativeFn();
+
+
+  // 2.A.1.1
+  // Use whitespace to promote readability
+
+  if (condition) {
+    // statements
+  }
+
+  var i,
+    length = 100;
+
+  for (i = 0; i < length; i++) {
+    // statements
+  }
+
+  var prop;
+
+  for (prop in object) {
+    // statements
+  }
+
+  if (true) {
+    // statements
+  } else {
+    // statements
+  }
+
+  ```
+
+
+  B. Assignments, Declarations, Functions (Named, Expression, Constructor)
+
+  ```javascript
+
+  // 2.B.1.1
+  // Variables
+
+  var foo = 'bar',
+    num = 1,
+    undef;
+
+  // Literal notations:
+  var array = [],
+    object = {};
+
+  or var array = [];
+  var object = {};
+
+  // 2.B.1.2
+  // var statements should always be in the beginning of their respective scope (function).
+
+  // Bad
+  function foo () {
+
+    // some statements here
+
+    var bar = '',
+      qux;
+  }
+
+  // Good
+  function foo () {
+    var bar = '',
+      qux;
+
+    // all statements after the variables declarations.
+  }
+
+  ```
+
+  ```javascript
+  // 2.B.2.1
+  // Named Function Declaration
+  function foo (arg1, argN) {
+
+  }
+
+  // Usage
+  foo(arg1, argN);
+
+  // 2.B.2.2
+  // Named Function Declaration
+  function square (number) {
+    return number * number;
+  }
+
+
+  // 2.B.2.3
+  // Function Expression
+  var square = function (number) {
+    // Return something valuable and relevant
+    return number * number;
+  };
+
+  // 2.B.2.4
+  // Constructor Declaration
+  function FooBar (options) {
+    this.options = options;
+  }
+
+  // Usage
+  var fooBar = new FooBar({a: 'alpha'});
+
+  fooBar.options;
+  // { a: 'alpha' }
+
+  ```
+
+  D<a name="quotes">. Quotes
+
+  Use **single** quotes in all JS.
+
+  ```javascript
+  // D.A.1
+  // exception
+
+  The only exception is with variable interpolation in CoffeeScript
+
+    console.info '#{param}'
+    // #{param}
+
+    console.info "#{param}"
+    // foo
+
+  ```
+
+  E. End of Lines and Empty Lines
+
+  Whitespace can ruin diffs and make changesets impossible to read. Whitespace commits should be made separately, and to avoid these, everyone should include whitespace removal in their editor's of choice.
+
+  ```javascript
+  // E.A.1
+  // Sublime Settings
+
+  "tab_size": 2,
+  "translate_tabs_to_spaces": true,
+  "trim_trailing_white_space_on_save": true,
+  "ensure_newline_at_eof_on_save": true,
+  "rulers": [80]
+
+  ```
+
+  F. Switch statements
+
+  ```javascript
+  switch (evt.keyCode) {
+    case App.keyCodes.ESCAPE:
+      this.close();
+      break;
+
+    case App.keyCodes.LEFT:
+      if (this.modalSetCount > 0) {
+        this.prevItem();
+      }
+      break;
+
+    case App.keyCodes.RIGHT:
+      if (this.modalSetCount > 0) {
+        this.nextItem();
+      }
+      break;
+
+    default:
+      break;
+  ```
+  Include a default statement when the value you\'re switching on could be `undefined`.
+
+3. <a name="type">Type Checking (Courtesy jQuery Core Style Guidelines)</a>
+
+    A. Actual Types
+
+    String:
+
+        typeof variable === "string"
+
+    Number:
+
+        typeof variable === "number"
+
+    Boolean:
+
+        typeof variable === "boolean"
+
+    Object:
+
+        typeof variable === "object"
+
+    Array:
+
+        Array.isArray( arrayLikeObject )
+        (wherever possible)
+
+    Node:
+
+        elem.nodeType === 1
+
+    null:
+
+        variable === null
+
+    null or undefined:
+
+        variable == null
+
+    undefined:
+
+      Global Variables:
+
+        typeof variable === "undefined"
+
+      Local Variables:
+
+        variable === undefined
+
+      Properties:
+
+        object.prop === undefined
+        object.hasOwnProperty( prop )
+        "prop" in object
+
+
+4. <a name="cond">Conditional Evaluation</a>
+
+  Prefer `===` over `==` (unless the case requires loose type evaluation, see 4.1.7)
+
+  ```javascript
+
+  // 4.1.1
+  // When only evaluating that an array has length,
+  // instead of this:
+  if (array.length > 0) ...
+
+  // ...evaluate truthiness, like this:
+  if (array.length) ...
+
+
+  // 4.1.2
+  // When only evaluating that an array is empty,
+  // instead of this:
+  if (array.length === 0) ...
+
+  // ...evaluate truthiness, like this:
+  if (!array.length) ...
+
+
+  // 4.1.3
+  // When only evaluating that a string is not empty,
+  // instead of this:
+  if (string !== '') ...
+
+  // ...evaluate truthiness, like this:
+  if (string) ...
+
+
+  // 4.1.4
+  // When only evaluating that a string _is_ empty,
+  // instead of this:
+  if (string === '') ...
+
+  // ...evaluate falsy-ness, like this:
+  if (!string) ...
+
+
+  // 4.1.5
+  // When only evaluating that a reference is true,
+  // instead of this:
+  if (foo === true) ...
+
+  // ...evaluate like you mean it, take advantage of built in capabilities:
+  if (foo) ...
+
+
+  // 4.1.6
+  // When evaluating that a reference is false,
+  // instead of this:
+  if (foo === false) ...
+
+  // ...use negation to coerce a true evaluation
+  if (!foo) ...
+
+  // ...Be careful, this will also match: 0, '', null, undefined, NaN
+  // If you _MUST_ test for a boolean false, then use
+  if (foo === false) ...
+
+
+  // 4.1.7
+  // When only evaluating a ref that might be null or undefined, but NOT false, '' or 0,
+  // instead of this:
+  if (foo === null || foo === undefined) ...
+
+  // ...take advantage of == type coercion, like this:
+  if (foo == null) ...
+
+  // Remember, using == will match a `null` to BOTH `null` and `undefined`
+  // but not `false`, '' or 0
+  null == undefined
+
+  ```
+
+  ALWAYS evaluate for the best, most accurate result - the above is a guideline, not a dogma.
+
+  ```javascript
+
+  // 4.2.1
+  // Type coercion and evaluation notes
+
+  // Use `===` vs. `==`
+
+  // === does not coerce type, which means that:
+
+  '1' === 1;
+  // false
+
+  // == does coerce type, which means that:
+
+  '1' == 1;
+  // true
+
+  // 4.2.2
+  // Booleans, Truthies & Falsies
+
+  // Booleans:
+  true, false
+
+  // Truthy:
+  'foo', 1
+
+  // Falsy:
+  '', 0, null, undefined, NaN, void 0
+  ```
+
+  Prefer plain `if` and `else` over additional `else if` conditions.
+  There is no `else if` in Javascript. You can iterate through multiple conditions
+  by using `return` in each statement - <http://rmurphey.com/blog/2012/12/10/js-conditionals/>
+
+  ```javascript
+
+  // 4.3.1
+
+  Instead of...
+  function howBig(num) {
+    if (num < 10) {
+      return 'small';
+    } else if (num >= 10 && num < 100) {
+      return 'medium';
+    } else if (num >= 100) {
+      return 'big';
+    }
+  }
+
+  do:
+  function howBig(num) {
+    if (num < 10) {
+      return 'small';
+    }
+
+    if (num < 100) {
+      return 'medium';
+    }
+
+    if (num >= 100) {
+      return 'big';
+    }
+  }
+  ```
+
+5. <a name="naming">Naming</a>
+
+  A. You are not a human code compiler/compressor, so don't try to be one.
+
+  The following code is an example of egregious naming:
+
+  ```javascript
+
+  // 5.A.1.1
+  // Example of code with poor names
+
+  function q(s) {
+    return document.querySelectorAll(s);
+  }
+  var i,a=[],els=q('#foo');
+  for(i=0;i<els.length;i++){a.push(els[i]);}
+  ```
+
+  Without a doubt, you've written code like this - hopefully that ends today.
+
+  Here's the same piece of logic, but with kinder, more thoughtful naming (and a readable structure):
+
+  ```javascript
+
+  // 5.A.2.1
+  // Example of code with improved names
+
+  function query (selector) {
+    return document.querySelectorAll(selector);
+  }
+
+  var idx = 0,
+    elements = [],
+    matches = query('#foo'),
+    length = matches.length;
+
+  for (idx < length; idx++) {
+    elements.push(matches[idx]);
+  }
+
+  ```
+
+  A few additional naming pointers:
+
+  ```javascript
+
+  // 5.A.3.1
+  // Naming strings
+
+  `dog` is a string
+
+
+  // 5.A.3.2
+  // Naming arrays
+
+  `dogs` is an array of `dog` strings
+
+
+  // 5.A.3.3
+  // Naming functions, objects, instances, etc
+
+  camelCase; function and var declarations
+
+  // 5.A.3.4
+  // Naming constructors, prototypes, etc.
+
+  PascalCase; constructor function
+
+  // 5.A.3.5
+  // Naming regular expressions
+
+  rDesc = //;
+
+  // 5.A.3.6
+  // Event Namespaces
+
+  snake_case; custom event namespaces as in the following
+
+  $('.foo').on('click.foo_click', clickHandler);
+
+
+  ```
+
+  B. Specific Naming Conventions
+
+  Specific conventions to help sanity. This is abritrary but helps immensely when working on large teams
+
+  ```javascript
+
+  // 5.B.1.0
+  Events in functions are to be passed in and saved as `evt`, not `e`, not `event`.
+
+  clickHandler = function (evt) {
+    evt.preventDefault();
+    this.to($(evt.delegateTarget).index());
+    this.open(evt);
+  }
+
+  ```
+6. <a name="comments">Comments</a>
+
+  * Single line above the code that is subject
+  * Multiline is good
+  * No End of line comments!
+
+7. <a name="jquery">jQuery</a>
+
+* jQuery is the library of choice for DOM manipulation. Outside of themes, new projects should use latest 2.x release
+* jQuery collections should be cached when used more than once, and saved with `$` prefix
+  * `var $navItems = $("#MainNav").find("li");`
+* `$(document).ready(function())` isn't a dumping ground. Use it to initialize a page but otherwise functionality should be organized into named functions with an easy to follow structure
+The prototype pattern has been used successfully and is readable
+  * eg. <https://github.com/Shopify/marketing_assets/blob/master/app/assets/javascripts/marketing_assets/modules/equal-height.js>
+* Plugins can be a huge time saver (eg for complex form validation or scroll detection), but these should be evaluated based on the following:
+  * is the plugin available for commercial use?
+  * how active is its Github repo? Are there many issues?
+  * have we already included a plugin that does a similar job? If so, that one should be used
+
+* CSS updates should happen from within CSS files.
+
+Instead of:
+
+```javascript
+$(".elem").style("color","red");
+```
+Use the following and add the styles in a CSS file:
+
+```javascript
+$(".elem").addClass("js-is-error");
+```
+
+* AJAX should use jQuery's `$.deferred` methods to avoid callback hell.
+
+Instead of:
+
+```javascript
+$.ajax({
+  success: function() {
+    $.ajax({
+      success: function() {
+        showData();
+    });
+  }
+});
+```
+
+Do this:
+
+```javascript
+$.when(async1(), async2()).then(showData);​
+```
+
+  * http://css-tricks.com/multiple-simultaneous-ajax-requests-one-callback-jquery/
+
+----------
+
+
+<a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/3.0/80x15.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">Principles of Writing Consistent, Idiomatic JavaScript</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/rwldrn/idiomatic.js" property="cc:attributionName" rel="cc:attributionURL">Rick Waldron and Contributors</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="https://github.com/rwldrn/idiomatic.js" rel="dct:source">github.com/rwldrn/idiomatic.js</a>.
+
+
+[&larr; Back to FED](/Front-End-Development)

--- a/react/README.md
+++ b/react/README.md
@@ -1,0 +1,492 @@
+# `import {React} from 'Shopify'`
+
+This guide provides a few guidelines on writing sensible React. Many of these rules are enforced by our [shared ESLint configuration](../packages/eslint-config-shopify), which makes use of the excellent [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) project.
+
+
+
+## Table of contents
+
+1. [Naming](#naming)
+1. [Whitespace](#whitespace)
+1. [Punctuation](#punctuation)
+1. [Components](#components)
+1. [Props](#props)
+
+
+
+## Naming
+
+- [1.1](#1.1) <a name="1.1"></a> Always use a `.js` file extension, even when that file contains JSX.
+
+- [1.2](#1.2) <a name="1.2"></a> React components are always named using PascalCase. Use camelCase for their instances.
+
+  ESLint rule: [`jsx-pascal-case`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md)
+
+  ```js
+  // bad
+  class financialReport extends React.Component {}
+  let MyReport = <financialReport />;
+
+  // good
+  class FinancialReport extends React.Component {}
+  let myReport = <FinancialReport />;
+  ```
+
+  - Use camelCase for all props.
+
+  ```js
+  // bad
+  class BadComponent extends React.Component {
+    static propTypes = {my_prop: React.PropTypes.bool}
+  }
+
+  // good
+  class GoodComponent extends React.Component {
+    static propTypes = {myProp: React.PropTypes.bool}
+  }
+  ```
+
+- [1.3](#1.3) <a name="1.3"></a> Try to define only one React component per file. Name that file the same as the component it exports, unless your component has static components that it also exports. In those cases, use `index.js` as the file that contains the main component for the directory.
+
+  ```js
+  // in Button.js
+  export default class Button extends React.Component {}
+
+  // in Field/Label.js
+  export default class Label extends React.Component {}
+
+  // in Field/index.js
+  import Label from './Label';
+
+  export default class Field extends React.Component {}
+  export {Label};
+
+  // in some other file...
+  import Button from './Button';
+  import Field, {Label} from './Field';
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Whitespace
+
+- [2.1](#2.1) <a name="2.1"></a> When there are no children for a component, use the self-closing tag. When using a self-closing tag for a component written on a single line, leave a single space between the last character and the closing of the tag.
+
+  ESLint rule: [`self-closing-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md)
+
+  ```js
+  // bad
+  <BadOne></BadOne>
+  <BadTwo/>
+  <BadThree    />
+  <BadFour
+    />
+
+  // good
+  <Good />
+  ```
+
+- [2.2](#2.2) <a name="2.2"></a> When writing a component that has multiple props, put a single prop per line, with two spaces of indentation, and a closing tag on a newline that aligns with the opening tag.
+
+  ESLint rule: [`jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)
+
+  ```js
+  // bad
+  <BadOne aLongPropName="a little too long"
+          anotherLongishPropName />
+
+  <BadTwo
+    aLongPropName="a little too long"
+    anotherLongishPropName>
+      <SubComponent>
+  </BadTwo>
+
+  // good
+  <GoodOne
+    aLongPropName="a little too long"
+    anotherLongishPropName
+  />
+
+  <GoodTwo
+    aLongPropName="a little too long"
+    anotherLongishPropName
+  >
+    <SubComponent>
+  </GoodTwo>
+  ```
+
+- [2.3](#2.3) <a name="2.3"></a> Never include spaces within the curly braces of JSX properties. Values within JSX properties should adhere to the same rules as if they appeared anywhere else in JavaScript (no interior spaces for object braces or brackets, interior space for function braces).
+
+  ESLint rule: [`jsx-curly-spacing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md)
+
+  ```js
+  // bad
+  <BadOne prop={ () => {console.log('callback');} } />
+  <BadTwo prop={[ 1, 2, 3 ]} />
+  <BadThree prop={{ foo: 'bar' }} />
+
+  // good
+  <BadOne prop={() => { console.log('callback'); }} />
+  <BadTwo prop={[1, 2, 3]} />
+  <BadThree prop={{foo: 'bar'}} />
+  ```
+
+- [2.4](#2.4) <a name="2.4"></a> Do not place a space on either side of the `=` in prop declarations.
+
+  ESLint rule: [`jsx-equals-spacing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md)
+
+  ```js
+  // bad
+  <Bad status = "is not very good" />
+
+  // good
+  <Good status="is great!" />
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Punctuation
+
+- [3.1](#3.1) <a name="3.1"></a> Use double quotes for JSX attributes.
+
+  > Why? Regular HTML attributes (and, in general, XML) typically use double quotes, so JSX attribute names follow this convention.
+
+  ESLint rule: [`jsx-quotes`](http://eslint.org/docs/rules/jsx-quotes)
+
+  ```js
+  // bad
+  <Bad prop='please, no!' />
+  <Bad propWithJS={{left: "20px"}} />
+
+  // good
+  <Good prop="please, no!" />
+  <Good propWithJS={{left: '20px'}} />
+  ```
+
+- [3.2](#3.2) <a name="3.2"></a> When JSX spans multiple lines, wrap them in parentheses. When on a single line, do not wrap in parentheses.
+
+  ESLint rule: [`wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md)
+
+  ```js
+  // bad
+  render() {
+    return <BadOne hasLongProp="sure does">
+             <SomeChildComponent />
+           </BadOne>
+  }
+
+  render() {
+    let {children} = this.props;
+    return (<BadTwo>{children}</BadTwo>);
+  }
+
+  // good
+  render() {
+    return (
+      <GoodOne hasLongProp="sure does">
+        <SomeChildComponent />
+      </GoodOne>
+    );
+  }
+
+  render() {
+    let {children} = this.props;
+    return <GoodTwo>{children}</GoodTwo>;
+  }
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Components
+
+- [4.1](#4.1) <a name="4.1"></a> Always extend React’s `Component` class rather than using `React.createClass`.
+
+  > Why? The `class` syntax is the method React is pushing going forward, and it’s how most tutorials are written.
+
+  ESLint rule: [`prefer-es6-class`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md)
+
+  ```js
+  // bad
+  let BadComponent = React.createClass({
+    render() {
+      return <div />;
+    },
+  });
+
+  // good
+  // (you can also just extend `Component` if you explicitly imported it)
+  class GoodComponent extends React.Component {
+    render() {
+      return <div />;
+    }
+  }
+  ```
+
+- [4.2](#4.2) <a name="4.2"></a> Always use JSX syntax and avoid `React.createElement`.
+
+  ```js
+  // bad
+  class BadComponent extends React.Component {
+    render() {
+      return React.createElement('div', {foo: 'bar'});
+    }
+  }
+
+  // good
+  class GoodComponent extends React.Component {
+    render() {
+      return <div foo="bar" />;
+    }
+  }
+  ```
+
+- [4.3](#4.3) <a name="4.3"></a> Prefer React’s stateless components for components that do not have any state or lifecycle hooks.
+
+  > **Note:** as of this writing, stateless components do not play nicely with React’s testing utilities. Until this is resolved, continue to extend `React.Component` for new components.
+
+  > Why? Such components are very easy to represent as pure functions, and doing so encourages more stateless components, which decreases application complexity.
+
+  ```js
+  // bad
+  export default class BadComponent extends React.Component {
+    render() {
+      let {children, hidden} = this.props;
+      return <div style={{opacity: hidden ? 0 : 1}}>{children}</div>;
+    }
+  }
+
+  // good
+  export default function GoodComponent({children, hidden}) {
+    return <div style={{opacity: hidden ? 0 : 1}}>{children}</div>;
+  }
+  ```
+
+- [4.4](#4.4) <a name="4.4"></a> Do not use underscore-prefixed methods in React components.
+
+  > Why? Most methods should either be lifecycle hooks, or callbacks, which are by definition not private since they are called by other components.
+
+  ```js
+  // bad
+  class BadComponent extends React.Component {
+    _handleButtonClick() {}
+  }
+
+  // good
+  class GoodComponent extends React.Component {
+    handleButtonClick() {}
+  }
+  ```
+
+- [4.5](#4.5) <a name="4.5"></a> When overriding the constructor of `React.Component`, make sure to call `super` with all arguments passed to the constructor. It is easiest to do this using the rest/ spread operator (`...`).
+
+  ```js
+  // bad
+  class BadComponent extends React.Component {
+    constructor() {
+      super();
+      this.doSomething();
+    }
+  }
+
+  // good
+  class GoodComponent extends React.Component {
+    constructor(...args) {
+      super(...args);
+      this.doSomething();
+    }
+  }
+  ```
+
+- [4.6](#4.6) <a name="4.6"></a> Prefer the `handle` prefix for callbacks passed to contained components.
+
+  > Why? The `handle` prefix clearly indicates its purpose, and differentiates it from `on`-prefixed properties which *accept* callbacks.
+
+  ```js
+  // bad
+  class BadComponent extends React.Component {
+    onClickButton() {}
+
+    render() {
+      return <button onClick={this.onClickButton}>Button</button>;
+    }
+  }
+
+  // good
+  class GoodComponent extends React.Component {
+    handleButtonClick() {}
+
+    render() {
+      return <button onClick={this.handleButtonClick}>Button</button>;
+    }
+  }
+  ```
+
+- [4.7](#4.7) <a name="4.7"></a> If you need to bind any of your methods, do so in the constructor.
+
+  > Why? Binding in `render` means that the function will be re-bound and re-assigned on every render of the component.
+
+  ```js
+  // bad
+  class BadComponent extends React.Component {
+    handleButtonClick() {}
+
+    render() {
+      return <button onClick={this.handleButtonClick.bind(this)}>Button</button>;
+    }
+  }
+
+  // good
+  class GoodComponent extends React.Component {
+    constructor(...args) {
+      super(...args);
+      this.handleButtonClick = this.handleButtonClick.bind(this);
+    }
+
+    handleButtonClick() {}
+
+    render() {
+      return <button onClick={this.handleButtonClick}>Button</button>;
+    }
+  }
+  ```
+
+- [4.8](#4.8) <a name="4.8"></a> Maintain a sensible ordering of methods in your component. At a high level, order the component as follows: statics, constructor, lifecycle methods, other methods (like handlers and helpers), and, finally, render (and any methods you have broken render up into).
+
+  > Why? A consistent ordering between components helps other developers find what they are looking for more quickly.
+
+  ESLint rule: [`sort-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md)
+
+- [4.9](#4.9) <a name="4.9"></a> Avoid violating the principles of React by doing things like directly setting state (use `setState`), setting state during the wrong lifecycle hooks (`componentDidMount` and `componentDidUpdate`), and checking whether your component is mounted.
+
+  > Why? These make your component harder to understand, and these features are either not supported or likely to be removed from future versions of React.
+
+  ESLint rules: [`no-deprecated`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md), [`no-did-mount-set-state`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md), [`no-did-update-set-state`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md), [`no-direct-mutation-state`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md), [`no-is-mounted`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md)
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)
+
+
+
+## Props
+
+- [5.1](#5.1) <a name="5.1"></a> Always include `propTypes` and `defaultProps` (where necessary).
+
+  > Why? `propTypes` provide a great way to enforce the type requirements of your component's API, and serve as documentation of what the component can do.
+
+  ESLint rule: [`prop-types`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md)
+
+  ```js
+  // bad
+  class BadComponent extends React.Component {
+    render() {
+      // what are these props?
+      let {propOne, propTwo = 'defaultValue'} = this.props;
+    }
+  }
+
+  // good
+  class GoodComponent extends React.Component {
+    static propTypes = {
+      propOne: React.PropTypes.bool,
+      propTwo: React.PropTypes.string,
+    }
+
+    static defaultProps = {propTwo: 'defaultValue'}
+
+    render() {
+      let {propOne, propTwo} = this.props;
+    }
+  }
+  ```
+
+- [5.2](#5.2) <a name="5.2"></a> Avoid generic `propTypes` that do not enforce type requirements, like `array` and `any`. Prefer more specific constraints, like `arrayOf`.
+
+  ESLint rule: [`forbid-prop-types`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md)
+
+  ```js
+  // bad
+  class BadComponent extends React.Component {
+    static propTypes = {choices: React.PropTypes.array}
+  }
+
+  // good
+  class BadComponent extends React.Component {
+    static propTypes = {
+      choices: React.PropTypes.arrayOf(React.PropTypes.string),
+    }
+  }
+  ```
+
+- [5.3](#5.3) <a name="5.3"></a> Where it makes sense, default boolean props to being false.
+
+  > Why? Opt-in APIs are typically easier to understand and test. It also allows you to make better use of the simpler boolean attributes detailed below.
+
+  ```js
+  // bad
+  class BadComponent extends React.Component {
+    static propTypes = {visible: React.PropTypes.bool}
+    static defaultProps = {visible: true}
+  }
+
+  let shouldBeHidden = <BadComponent visible={false} />
+
+  // good
+  class GoodComponent extends React.Component {
+    static propTypes = {hidden: React.PropTypes.bool}
+    static defaultProps = {hidden: false}
+  }
+
+  let shouldBeHidden = <GoodComponent hidden />
+  ```
+
+- [5.4](#5.4) <a name="5.4"></a> Omit the value of a prop when it is explicitly true.
+
+  > Why? It reduces visual noise and matches how we would write similar attributes in HTML.
+
+  ESLint rule: [`jsx-boolean-value`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md)
+
+  ```js
+  // bad
+  <Bad hidden={true} />
+
+  // good
+  <Good hidden />
+  <Good hidden={false} />
+  ```
+
+- [5.5](#5.5) <a name="5.5"></a> Omit curly braces when the prop is a string.
+
+  > Why? It is cleaner and matches how most attributes are defined in HTML.
+
+  ```js
+  // bad
+  <Bad status={"unnecessary braces"} />
+
+  // good
+  <Good status="nice and clean" />
+  ```
+
+- [5.6](#5.6) <a name="5.6"></a> Name props that act as event listeners `on<EventName`.
+
+  ```js
+  // bad
+  class BadComponent extends React.Component {
+    static propTypes = {click: React.PropTypes.func}
+  }
+
+  <BadComponent click={() => console.log('clicked')} />
+
+  // good
+  class GoodComponent extends React.Component {
+    static propTypes = {onClick: React.PropTypes.func}
+  }
+
+  <GoodComponent onClick={() => console.log('clicked')} />
+  ```
+
+[↑ scrollTo('#table-of-contents')](#table-of-contents)


### PR DESCRIPTION
This PR revamps our JavaScript documentation with a focus on ES2015+. I've added dedicated documentation for "vanilla" JS, React, and jQuery. Where possible, I've linked to the ESLint rule that we have put in place to enforce a particular style guide rule. You'll notice that this repo actually has submodules pointing our other JS-related packages, most notably our shared ESLint config.

For reference, here's the current JS style guide (which would be replaced by this one): https://vault.shopify.com/Front-End-Development/JavaScript-Style-Guide

Some goals for this guide are:
- To document how our code should be, not necessarily how it is.
- To document stylistic conventions, not the way in which we build applications (I think a separate document would be better for that).
- To be clearer than might seem necessary, so that there's no ambiguity and we don't have to argue about the rules.

I would love some feedback on the way rules are described, groupings, examples, and additional resources. If we have a major problem with a particular rule we can put it here, but it is probably better to do it as an issue on the [ESLint config repo](https://github.com/Shopify/eslint-config-shopify).

cc/ @Shopify/fed 
cc/ @bouk @jahfer @73rhodes @tedtate @patrickdonovan 
(if there is anyone else who should be pinged on this, please let me know!)

Note: I split the main guide up into multiple files just for the purposes of review — Github wouldn't show the diff of the full file. When I merge this, I will recombine back into a single document.
