### PR TITLE
ESLint 2.0, Round 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ npm run lint
 
 - [4.5](#4.5) <a name="4.5"></a> Place one space before the opening parenthesis in control statements (`if`, `while`, etc). Place no space between the function name and argument list in function calls and declarations.
 
-  ESLint rules: [`space-after-keywords`](http://eslint.org/docs/rules/space-after-keywords.html), [`space-before-keywords`](http://eslint.org/docs/rules/space-before-keywords.html)
+  ESLint rule: [`keyword-spacing`](http://eslint.org/docs/rules/keyword-spacing.html)
 
   ```js
   // bad
@@ -492,7 +492,7 @@ npm run lint
 
   > Why? Breaking a method chain across lines improves readability. The leading dot clearly emphasizes that this is a method call, not a new statement.
 
-  ESLint rule: [`dot-location`](http://eslint.org/docs/rules/dot-location.html)
+  ESLint rules: [`dot-location`](http://eslint.org/docs/rules/dot-location.html), [`newline-per-chained-call`](http://eslint.org/docs/rules/newline-per-chained-call.html)
 
   ```js
   const result = [1, 2, 3, 4, 5].filter((x) => x > 2).map((x) => x * x * x).reduce((total, x) => total + x, 0);
@@ -1139,11 +1139,11 @@ npm run lint
     'shepherds the weak through the valley of darkness';
   ```
 
-- [9.3](#9.3) <a name="9.3"></a> Use template strings instead of concatenation.
+- [9.3](#9.3) <a name="9.3"></a> Use template strings instead of concatenation. When ambedding expressions in the template strings, never include spaces within the curly braces.
 
   > Why? The template string syntax is easier to read and consistent with how we build strings programatically in other languages.
 
-  ESLint rule: [`prefer-template`](http://eslint.org/docs/rules/prefer-template.html)
+  ESLint rules: [`prefer-template`](http://eslint.org/docs/rules/prefer-template.html), [`template-curly-spacing`](http://eslint.org/docs/rules/template-curly-spacing.html)
 
   ```javascript
   const name = 'Chris';
@@ -1151,6 +1151,7 @@ npm run lint
   // bad
   const badOne = 'DO NOT do it this way, ' + name + '!';
   const badTwo = ['And definitely not this way, either, ', name, '!'].join('');
+  const badThree = `So close, ${ name }, but so far!`;
 
   // good
   const goodOne = `Much better, ${name}!`;
@@ -1369,6 +1370,8 @@ npm run lint
 ### Parameters
 
 - [10.12](#10.12) <a name="10.12"></a> Never use the implicitly defined `arguments` array-like object provided by functions. Instead, use rest syntax (`...`) to describe variadic arguments.
+
+  ESLint rule: [`prefer-rest-params`](http://eslint.org/docs/rules/prefer-rest-params.html)
 
   > Why? `...` is explicit in which arguments you want pulled, and covers the boilerplate of assigning parameters out of `arguments`. It also provides an actual array, so all array prototype methods are available.
 
@@ -1854,6 +1857,10 @@ npm run lint
 
 - [Javascript Air](http://audio.javascriptair.com)
 - [JavaScript Jabber](https://devchat.tv/js-jabber/)
+
+### Other
+
+- [ECMAScript current proposals](https://github.com/tc39/ecma262/blob/master/README.md), including the [stage 0 proposals](https://github.com/tc39/ecma262/blob/master/stage0.md)
 
 
 [↑ scrollTo('#table-of-contents')](#table-of-contents)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint . --max-warnings 0",
     "test": "cd packages/eslint-plugin-shopify && npm test && cd ../generator-eslint-shopify && npm test && cd ../..",
     "check": "npm run lint && npm test",
-    "setup": "npm install && lerna bootstrap",
+    "setup": "rimraf **/node_modules && npm install && lerna bootstrap",
     "updated": "lerna updated",
     "publish-all": "npm run check && lerna publish"
   },
@@ -18,10 +18,10 @@
   "author": "Chris Sauve <chrismsauve@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "babel-eslint": "^4.1.8",
-    "eslint": "^1.10.3",
+    "eslint": "^2.1.0",
     "eslint-config-shopify": "file:./packages/eslint-config-shopify",
     "eslint-plugin-shopify": "file:./packages/eslint-plugin-shopify",
-    "lerna": "kittens/lerna#73dd8f1"
+    "lerna": "^1.1.1",
+    "rimraf": "^2.5.2"
   }
 }

--- a/packages/eslint-config-shopify/.eslintrc
+++ b/packages/eslint-config-shopify/.eslintrc
@@ -1,7 +1,6 @@
 {
   "extends": "shopify/es5",
   "rules": {
-    // For consistency with keys that require quotes
     "quote-props": 0
   }
 }

--- a/packages/eslint-config-shopify/core/index.js
+++ b/packages/eslint-config-shopify/core/index.js
@@ -5,6 +5,10 @@ module.exports = {
     'shopify',
   ],
 
+  ecmaFeatures: {
+    ecmaVersion: 5,
+  },
+
   rules: merge(
     require('../rules/best-practices'),
     require('../rules/legacy'),

--- a/packages/eslint-config-shopify/es6/index.js
+++ b/packages/eslint-config-shopify/es6/index.js
@@ -1,4 +1,5 @@
 var merge = require('merge');
+var coreConfig = require('../core');
 
 module.exports = {
   extends: 'shopify/core',
@@ -9,9 +10,13 @@ module.exports = {
     node: true,
   },
 
-  ecmaFeatures: {
-    modules: true,
-  },
+  parserOptions: merge.recursive(
+    coreConfig.parserOptions,
+    {
+      ecmaVersion: 6,
+      sourceType: 'module',
+    }
+  ),
 
   rules: merge(
     require('../rules/ecmascript-6'),

--- a/packages/eslint-config-shopify/package.json
+++ b/packages/eslint-config-shopify/package.json
@@ -20,14 +20,14 @@
   "homepage": "https://github.com/Shopify/javascript/tree/master/packages/eslint-config-shopify",
   "repository": "https://github.com/Shopify/javascript/tree/master/packages/eslint-config-shopify",
   "optionalDependencies": {
-    "babel-eslint": "^4.1.8",
     "eslint-plugin-react": "^3.16.1"
   },
   "peerDependencies": {
-    "eslint": ">=1.10.0",
+    "eslint": ">=2.1.0",
     "eslint-plugin-shopify": "^7.0.0"
   },
   "dependencies": {
-    "merge": "^1.2.0"
+    "merge": "^1.2.0",
+    "babel-eslint": "^4.1.8"
   }
 }

--- a/packages/eslint-config-shopify/react/index.js
+++ b/packages/eslint-config-shopify/react/index.js
@@ -1,3 +1,6 @@
+var merge = require('merge');
+var es6Config = require('../es6');
+
 module.exports = {
   extends: 'shopify/es6',
 
@@ -6,9 +9,12 @@ module.exports = {
     'shopify',
   ],
 
-  ecmaFeatures: {
-    jsx: true,
-  },
+  parserOptions: merge.recursive(
+    es6Config.parserOptions,
+    {
+      ecmaFeatures: {jsx: true},
+    }
+  ),
 
   globals: {
     fetch: true,

--- a/packages/eslint-config-shopify/rules/best-practices.js
+++ b/packages/eslint-config-shopify/rules/best-practices.js
@@ -3,6 +3,8 @@
 module.exports = {
   // Enforces getter/setter pairs in objects
   'accessor-pairs': 0,
+  // Enforces return statements in callbacks of array's methods
+  'array-callback-return': 2,
   // Treat var statements as if they were block scoped
   'block-scoped-var': 1,
   // Specify the maximum cyclomatic complexity allowed in a program
@@ -31,8 +33,8 @@ module.exports = {
   'no-div-regex': 1,
   // Disallow else after a return in an if
   'no-else-return': 0,
-  // Disallow use of labels for anything other than loops and switches
-  'no-empty-label': 2,
+  // Disallow use of empty functions
+  'no-empty-function': 1,
   // Disallow use of empty destructuring patterns
   'no-empty-pattern': 2,
   // Disallow comparisons to null without a type-checking operator
@@ -43,12 +45,16 @@ module.exports = {
   'no-extend-native': 2,
   // Disallow unnecessary function binding
   'no-extra-bind': 1,
+  // Disallow unnecessary labels
+  'no-extra-label': 2,
   // Disallow fallthrough of case statements
   'no-fallthrough': 2,
   // Disallow the use of leading or trailing decimal points in numeric literals
   'no-floating-decimal': 1,
   // Disallow the type conversions with shorter notations
   'no-implicit-coercion': 1,
+  // Disallow var and named functions in global scope
+  'no-implicit-globals': 1,
   // Disallow use of eval()-like methods
   'no-implied-eval': 2,
   // Disallow this keywords outside of classes or class-like objects
@@ -92,14 +98,20 @@ module.exports = {
   'no-return-assign': 2,
   // Disallow use of javascript: urls.,
   'no-script-url': 0,
+  // Disallow assignments where both sides are exactly the same
+  'no-self-assign': 2,
   // Disallow comparisons where both sides are exactly the same
   'no-self-compare': 2,
   // Disallow use of comma operator
   'no-sequences': 1,
   // Restrict what can be thrown as an exception
   'no-throw-literal': 1,
-  // Allow usage of expressions in statement position
+  // Disallow unmodified conditions of loops
+  'no-unmodified-loop-condition': 2,
+  // Disallow usage of expressions in statement position
   'no-unused-expressions': 1,
+  // Disallow unused labels
+  'no-unused-labels': 2,
   // Disallow unnecessary .call() and .apply()
   'no-useless-call': 2,
   // Disallow unnecessary concatenation of literals or template literals

--- a/packages/eslint-config-shopify/rules/ecmascript-6.js
+++ b/packages/eslint-config-shopify/rules/ecmascript-6.js
@@ -13,12 +13,18 @@ module.exports = {
   'generator-star-spacing': [1, 'after'],
   // Disallow modifying variables of class declarations
   'no-class-assign': 1,
+  // Disallow arrow functions where they could be confused with comparisons
+  'no-confusing-arrow': 2,
   // Disallow modifying variables that are declared using const
   'no-const-assign': 2,
   // Disallow duplicate name in class members
   'no-dupe-class-members': 2,
+  // Disallow use of the new operator with the Symbol object
+  'no-new-symbol': 2,
   // Disallow to use this/super before super() calling in constructors.
   'no-this-before-super': 2,
+  // Disallow unnecessary constructor
+  'no-useless-constructor': 1,
   // Require let or const instead of var
   'no-var': 2,
   // Require method and property shorthand syntax for object literals
@@ -27,6 +33,8 @@ module.exports = {
   'prefer-arrow-callback': 2,
   // Suggest using of const declaration for variables that are never modified after declared
   'prefer-const': 1,
+  // Suggest using the rest parameters instead of arguments
+  'prefer-rest-params': 2,
   // Suggest using the spread operator instead of .apply()
   'prefer-spread': 2,
   // Suggest using Reflect methods where applicable
@@ -35,4 +43,8 @@ module.exports = {
   'prefer-template': 1,
   // Disallow generator functions that do not have yield
   'require-yield': 2,
+  // Enforce spacing around embedded expressions of template strings
+  'template-curly-spacing': [1, 'never'],
+  // Enforce spacing around the * in yield* expressions
+  'yield-star-spacing': [1, {before: false, after: true}],
 };

--- a/packages/eslint-config-shopify/rules/node.js
+++ b/packages/eslint-config-shopify/rules/node.js
@@ -15,6 +15,8 @@ module.exports = {
   'no-path-concat': 1,
   // Disallow process.exit()
   'no-process-exit': 1,
+  // Restrict usage of specified node imports
+  'no-restricted-imports': 0,
   // Restrict usage of specified node modules
   'no-restricted-modules': 0,
   // Disallow use of synchronous methods

--- a/packages/eslint-config-shopify/rules/stylistic-issues.js
+++ b/packages/eslint-config-shopify/rules/stylistic-issues.js
@@ -23,8 +23,10 @@ module.exports = {
   'func-names': 0,
   // Enforces use of function declarations or expressions
   'func-style': [1, 'declaration'],
+  // Blacklist certain identifiers to prevent them being used
+  'id-blacklist': 0,
   // This option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-  'id-length': [1, {min: 2, properties: 'always', exceptions: ['x', 'y', 'i', 'j', '_']}],
+  'id-length': [1, {min: 2, properties: 'always', exceptions: ['x', 'y', 'i', 'j', '_', '$']}],
   // Require identifiers to match the provided regular expression
   'id-match': 0,
   // This option sets a specific tab width for your code
@@ -33,10 +35,12 @@ module.exports = {
   'jsx-quotes': [1, 'prefer-double'],
   // Enforces spacing between keys and values in object literal properties
   'key-spacing': [1, {beforeColon: false, afterColon: true}],
-  // Enforces empty lines around comments
-  'lines-around-comment': [1, {beforeBlockComment: true}],
+  // Enforce spacing before and after keywords
+  'keyword-spacing': [1, {before: true, after: true, overrides: {}}],
   // Disallow mixed "LF" and "CRLF" as linebreaks
   'linebreak-style': 0,
+  // Enforces empty lines around comments
+  'lines-around-comment': [1, {beforeBlockComment: true}],
   // Specify the maximum depth callbacks can be nested
   'max-nested-callbacks': 0,
   // Require a capital letter for constructors
@@ -45,6 +49,8 @@ module.exports = {
   'new-parens': 1,
   // Allow/disallow an empty newline after var statement
   'newline-after-var': 0,
+  // Enforce newline after each call when chaining the calls
+  'newline-per-chained-call': [1, {ignoreChainWithDepth: 3}],
   // Disallow use of the Array constructor
   'no-array-constructor': 2,
   // Disallow use of the continue statement
@@ -71,10 +77,14 @@ module.exports = {
   'no-underscore-dangle': 0,
   // Disallow the use of Boolean literals in conditional expressions
   'no-unneeded-ternary': 1,
+  // Disallow whitespace before properties
+  'no-whitespace-before-property': 2,
   // Require or disallow padding inside curly braces
   'object-curly-spacing': [1, 'never'],
   // Allow or disallow one variable declaration per function
   'one-var': [1, 'never'],
+  // Require or disallow an newline around variable declarations
+  'one-var-declaration-per-line': [1, 'initializations'],
   // Require assignment operator shorthand where possible or prohibit it entirely
   'operator-assignment': [1, 'always'],
   // Enforce operators to be placed before or after line breaks
@@ -89,10 +99,10 @@ module.exports = {
   'semi-spacing': [1, {before: false, after: true}],
   // Require or disallow use of semicolons instead of ASI
   'semi': [1, 'always'],
+  // Sort import declarations within module
+  'sort-imports': 0,
   // Sort variables within the same declaration block
   'sort-vars': 0,
-  // Require a space after certain keywords
-  'space-after-keywords': [1, 'always'],
   // Require or disallow space before blocks
   'space-before-blocks': [1, 'always'],
   // Require or disallow space before function opening parenthesis
@@ -101,8 +111,6 @@ module.exports = {
   'space-in-parens': [1, 'never'],
   // Require spaces around operators
   'space-infix-ops': 1,
-  // Require a space after return, throw, and case
-  'space-return-throw-case': 1,
   // Require or disallow spaces before/after unary operators (words on by default, nonwords)
   'space-unary-ops': [1, {words: true, nonwords: false}],
   // Require or disallow a space immediately following the // or /* in a comment

--- a/packages/eslint-plugin-shopify/index.js
+++ b/packages/eslint-plugin-shopify/index.js
@@ -3,9 +3,4 @@ module.exports = {
     'require-flow': require('./lib/rules/require-flow'),
     'binary-assignment-parens': require('./lib/rules/binary-assignment-parens'),
   },
-
-  rulesConfig: {
-    'require-flow': 0,
-    'binary-assignment-parens': 0,
-  },
 };

--- a/packages/generator-eslint-shopify/.eslintrc
+++ b/packages/generator-eslint-shopify/.eslintrc
@@ -1,9 +1,5 @@
 {
   "extends": "shopify",
-  "parser": "babel-eslint",
-  "plugins": [
-    "shopify"
-  ],
   "env": {
     "es6": true,
     "node": true


### PR DESCRIPTION
This PR does most of the required updates for ESLint 2.0, including:

- Added configurations for new rules and removed deprecated/ deleted rules (and updated the README accordingly).
- Updated the configs for the new `parserOptions` key.
- Removed the `rulesConfig` for the plugin.
- Did all the necessary dependency updates.

I omitted one important thing to keep this PR easy to review: ESLint allows us to bundle our config with our plugin, which will allow us to basically get the required packages down to 1. The config for consuming projects looks a bit worse (`{"extends": "plugin:shopify/es6"}` instead of `{"extends": "shopify"}`), but I think that's an acceptable tradeoff. If no one has any objections, I will do that work in an additional PR.

cc/ @Shopify/fed @bouk 