### PR TITLE
Consolidate plugin and config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,19 +4,13 @@ This repo actually contains multiple projects in addition to the formal stylegui
 script/setup
 ```
 
-Make *every* required change across all repos. For a given rule change, this will often involve at least a change to `eslint-config-shopify` and to the README for this repo. You can lint and test your changes across all repos by running:
+Make *every* required change across all repos. For a given rule change, this will often involve at least a change to `eslint-plugin-shopify` and to the README for this repo. You can lint and test your changes across all repos by running:
 
 ```bash
 script/test
 ```
 
-Once you are satisfied with your changes, open a pull request and get your changes merged. Then, follow these steps:
-
-- Update any relevant dependencies (for example, if updating `eslint-plugin-shopify`, update the peer dependency for `eslint-config-shopify`) to the version you are going to bump to
-- Update the `CHANGELOG.md` file at the root of the repo
-- Commit all of these version-related changes
-
-Finally, run the publishing command:
+Once you are satisfied with your changes, open a pull request and get your changes merged. Then, update the `CHANGELOG.md` file at the root of this repo with the changes you have made. Finally, run the publishing command:
 
 ```bash
 script/publish

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Have a legacy codebase? Can’t use ES2015? Our [legacy styleguide](legacy/) is 
 
 ## Using this guide
 
-Many of the following rules are enforced by our [shared ESLint config](packages/eslint-config-shopify), which you can use in most editors and CI environments. To use it, you will need to have [Node.js and npm installed](https://docs.npmjs.com/getting-started/installing-node). Once these are installed, you have two options for adding ESLint to your project: using our Yeoman generator, or installing everything manually.
+Many of the following rules are enforced by our [shared ESLint config/ plugin](packages/eslint-config-plugin), which you can use in most editors and CI environments. To use it, you will need to have [Node.js and npm installed](https://docs.npmjs.com/getting-started/installing-node). Once these are installed, you have two options for adding ESLint to your project: using our Yeoman generator, or installing everything manually.
 
 ### Yeoman Generator
 
@@ -60,24 +60,15 @@ npm run lint
 ### Manually
 
 ```bash
-npm install eslint eslint-config-shopify eslint-plugin-shopify --save-dev
-
-# also, if using ES2015+:
-npm install babel-eslint --save-dev
-
-# finally, if using React:
-npm install eslint-plugin-react --save-dev
+npm install eslint eslint-plugin-shopify --save-dev
 ```
 
 Once these are installed, you will need to add a `.eslintrc` file at the root of your project that specifies that you'd like to extend the Shopify configuration.
 
 ```js
 {
-  "extends": "shopify", // or "shopify/es5" for the ES5 config, "shopify/react" for the React config
-  "parser": "babel-eslint", // unless using ES5
-  "plugins": [
-    "shopify", // add "react" here too if in a React project
-  ],
+  // or "plugin:shopify/es5" for the ES5 config, "plugin:shopify/react" for the React config
+  "extends": "plugin:shopify/esnext",
   // choose your environments: http://eslint.org/docs/user-guide/configuring.html#specifying-environments
   "env": {}
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "devDependencies": {
     "eslint": "^2.1.0",
-    "eslint-config-shopify": "file:./packages/eslint-config-shopify",
     "eslint-plugin-shopify": "file:./packages/eslint-plugin-shopify",
     "lerna": "^1.1.1",
     "rimraf": "^2.5.2"

--- a/packages/eslint-config-shopify/.eslintrc
+++ b/packages/eslint-config-shopify/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "shopify/es5",
+  "extends": "plugin:shopify/es5",
   "rules": {
     "quote-props": 0
   }

--- a/packages/eslint-config-shopify/README.md
+++ b/packages/eslint-config-shopify/README.md
@@ -1,6 +1,8 @@
 # eslint-config-shopify
 
-[![Build status][circle-image]][circle-url] [![NPM version][npm-image]][npm-url]
+## Note: as of version 8.0.0, this package is deprecated. Instead, use the configs found in the [`eslint-plugin-shopify`](../eslint-plugin-shopify) package, which make use of the plugin configs introduced in ESLint 2.0.0.
+
+[![NPM version][npm-image]][npm-url]
 
 This package provides Shopify's `.eslintrc` as an extensible shared config.
 
@@ -59,5 +61,3 @@ then, extend the ES5 version of this configuration in your own `.eslintrc`:
 
 [npm-url]: https://npmjs.org/package/eslint-config-shopify
 [npm-image]: http://img.shields.io/npm/v/eslint-config-shopify.svg?style=flat-square
-[circle-url]: https://circleci.com/gh/Shopify/eslint-config-shopify
-[circle-image]: https://circleci.com/gh/Shopify/eslint-config-shopify.svg?&style=shield&circle-token=3734ea0a376393800642813772f4b474c7a14a4e

--- a/packages/eslint-plugin-shopify/.eslintrc
+++ b/packages/eslint-plugin-shopify/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "shopify/es5"
+  "extends": "plugin:shopify/es5"
 }

--- a/packages/eslint-plugin-shopify/README.md
+++ b/packages/eslint-plugin-shopify/README.md
@@ -1,8 +1,8 @@
 # eslint-plugin-shopify
 
-[![Build status][circle-image]][circle-url] [![NPM version][npm-image]][npm-url]
+[![NPM version][npm-image]][npm-url]
 
-Shopify-specific ESLint rules.
+Shopify’s ESLint rules and configs.
 
 ## Installation
 
@@ -22,37 +22,40 @@ $ npm install eslint-plugin-shopify --save-dev
 
 ## Usage
 
-Add `shopify` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+Shopify’s ESLint configs come bundled in this package. In order to use them, you simply extend the relevant configuration in your project’s `.eslintrc`. For example, the following will extend the ESNext (ES2015 and later) config:
 
 ```json
 {
-  "plugins": [
-    "shopify"
-  ]
+  "extends": "plugin:shopify/esnext"
 }
 ```
 
-
-Then configure the rules you want to use under the rules section.
+If using React, extend the React version of the configuration (which adds some React-specific rules to those in the ESNext config):
 
 ```json
 {
-  "rules": {
-    "shopify/require-flow": 2
-  }
+  "extends": "plugin:shopify/react"
 }
 ```
 
-## Supported Rules
+If working on an ES5 project, extend the ES5 version of the configuration:
+
+```json
+{
+  "extends": "plugin:shopify/es5"
+}
+```
+
+## Plugin-Provided Rules
+
+This plugin provides the following custom rules:
 
 - [require-flow](docs/rules/require-flow.md): Requires (or disallows) @flow declarations be present at the top of each file.
 - [binary-assignment-parens](docs/rules/binary-assignment-parens.md): Requires (or disallows) assignments of binary, boolean-producing expressions to be wrapped in parentheses.
 
-## Contributing
+## Creating New Rules
 
 The easiest way to add new rules is to use the [ESLint Yeoman generator](https://www.npmjs.com/package/generator-eslint). Running `yo eslint:rule` from the root of this project should add the required main file, docs, and test for your new rules. Make sure that these are all filled out and consistent with the other rules before merging. All tests (including linting) can be run using `npm test`.
 
 [npm-url]: https://npmjs.org/package/eslint-plugin-shopify
 [npm-image]: http://img.shields.io/npm/v/eslint-plugin-shopify.svg?style=flat-square
-[circle-url]: https://circleci.com/gh/Shopify/eslint-plugin-shopify
-[circle-image]: https://circleci.com/gh/Shopify/eslint-plugin-shopify.svg?&style=shield&circle-token=12c1aa1992fe3b92a6bcabfe1a6416ae7a69e35b

--- a/packages/eslint-plugin-shopify/index.js
+++ b/packages/eslint-plugin-shopify/index.js
@@ -3,4 +3,11 @@ module.exports = {
     'require-flow': require('./lib/rules/require-flow'),
     'binary-assignment-parens': require('./lib/rules/binary-assignment-parens'),
   },
+
+  configs: {
+    core: require('./lib/config/core'),
+    es5: require('./lib/config/es5'),
+    esnext: require('./lib/config/esnext'),
+    react: require('./lib/config/react'),
+  },
 };

--- a/packages/eslint-plugin-shopify/lib/config/.eslintrc
+++ b/packages/eslint-plugin-shopify/lib/config/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "quote-props": 0
+  }
+}

--- a/packages/eslint-plugin-shopify/lib/config/core/index.js
+++ b/packages/eslint-plugin-shopify/lib/config/core/index.js
@@ -1,0 +1,21 @@
+var merge = require('merge');
+
+module.exports = {
+  plugins: [
+    'shopify',
+  ],
+
+  ecmaFeatures: {
+    ecmaVersion: 5,
+  },
+
+  rules: merge(
+    require('../rules/best-practices'),
+    require('../rules/legacy'),
+    require('../rules/possible-errors'),
+    require('../rules/shopify'),
+    require('../rules/strict-mode'),
+    require('../rules/stylistic-issues'),
+    require('../rules/variables')
+  ),
+};

--- a/packages/eslint-plugin-shopify/lib/config/es5/index.js
+++ b/packages/eslint-plugin-shopify/lib/config/es5/index.js
@@ -1,0 +1,14 @@
+var merge = require('merge');
+
+module.exports = {
+  extends: 'plugin:shopify/core',
+
+  env: {
+    node: true,
+  },
+
+  rules: merge(
+    require('../rules/node'),
+    {'shopify/require-flow': 0}
+  ),
+};

--- a/packages/eslint-plugin-shopify/lib/config/esnext/index.js
+++ b/packages/eslint-plugin-shopify/lib/config/esnext/index.js
@@ -1,0 +1,25 @@
+var merge = require('merge');
+var coreConfig = require('../core');
+
+module.exports = {
+  extends: 'plugin:shopify/core',
+  parser: 'babel-eslint',
+
+  env: {
+    es6: true,
+    node: true,
+  },
+
+  parserOptions: merge.recursive(
+    coreConfig.parserOptions,
+    {
+      ecmaVersion: 6,
+      sourceType: 'module',
+    }
+  ),
+
+  rules: merge(
+    require('../rules/ecmascript-6'),
+    {'no-param-reassign': 0} // because of default params
+  ),
+};

--- a/packages/eslint-plugin-shopify/lib/config/react/index.js
+++ b/packages/eslint-plugin-shopify/lib/config/react/index.js
@@ -1,0 +1,26 @@
+var merge = require('merge');
+var es6Config = require('../esnext');
+
+module.exports = {
+  extends: 'plugin:shopify/esnext',
+
+  plugins: [
+    'react',
+    'shopify',
+  ],
+
+  parserOptions: merge.recursive(
+    es6Config.parserOptions,
+    {
+      ecmaFeatures: {jsx: true},
+    }
+  ),
+
+  globals: {
+    fetch: true,
+    ReactElement: true,
+    ReactClass: true,
+  },
+
+  rules: require('../rules/react'),
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/best-practices.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/best-practices.js
@@ -1,0 +1,133 @@
+// see http://eslint.org/docs/rules/#best-practices
+
+module.exports = {
+  // Enforces getter/setter pairs in objects
+  'accessor-pairs': 0,
+  // Enforces return statements in callbacks of array's methods
+  'array-callback-return': 2,
+  // Treat var statements as if they were block scoped
+  'block-scoped-var': 1,
+  // Specify the maximum cyclomatic complexity allowed in a program
+  'complexity': 0,
+  // Require return statements to either always or never specify values
+  'consistent-return': 1,
+  // Specify curly brace conventions for all control statements
+  'curly': [1, 'all'],
+  // Require default case in switch statements
+  'default-case': 0,
+  // Encourages use of dot notation whenever possible
+  'dot-notation': [1, {allowKeywords: true}],
+  // Enforces consistent newlines before or after dots
+  'dot-location': [1, 'property'],
+  // Require the use of === and !==
+  'eqeqeq': [2, 'allow-null'],
+  // Make sure for-in loops have an if statement
+  'guard-for-in': 1,
+  // Disallow the use of alert, confirm, and prompt
+  'no-alert': 1,
+  // disallow lexical declarations in case clauses
+  'no-case-declarations': 2,
+  // Disallow use of arguments.caller or arguments.callee
+  'no-caller': 2,
+  // Disallow division operators explicitly at beginning of regular expression
+  'no-div-regex': 1,
+  // Disallow else after a return in an if
+  'no-else-return': 0,
+  // Disallow use of empty functions
+  'no-empty-function': 1,
+  // Disallow use of empty destructuring patterns
+  'no-empty-pattern': 2,
+  // Disallow comparisons to null without a type-checking operator
+  'no-eq-null': 0,
+  // Disallow use of eval()
+  'no-eval': 2,
+  // Disallow adding to native types
+  'no-extend-native': 2,
+  // Disallow unnecessary function binding
+  'no-extra-bind': 1,
+  // Disallow unnecessary labels
+  'no-extra-label': 2,
+  // Disallow fallthrough of case statements
+  'no-fallthrough': 2,
+  // Disallow the use of leading or trailing decimal points in numeric literals
+  'no-floating-decimal': 1,
+  // Disallow the type conversions with shorter notations
+  'no-implicit-coercion': 1,
+  // Disallow var and named functions in global scope
+  'no-implicit-globals': 1,
+  // Disallow use of eval()-like methods
+  'no-implied-eval': 2,
+  // Disallow this keywords outside of classes or class-like objects
+  'no-invalid-this': 0,
+  // Disallow usage of __iterator__ property
+  'no-iterator': 2,
+  // Disallow use of labeled statements
+  'no-labels': 2,
+  // Disallow unnecessary nested blocks
+  'no-lone-blocks': 1,
+  // Disallow creation of functions within loops
+  'no-loop-func': 2,
+  // Disallow the use of magic numbers
+  'no-magic-numbers': 0,
+  // Disallow use of multiple spaces
+  'no-multi-spaces': 1,
+  // Disallow use of multiline strings
+  'no-multi-str': 0,
+  // Disallow reassignments of native objects
+  'no-native-reassign': 2,
+  // Disallow use of new operator for Function object
+  'no-new-func': 2,
+  // Disallows creating new instances of String, Number, and Boolean
+  'no-new-wrappers': 2,
+  // Disallow use of new operator when not part of the assignment or comparison
+  'no-new': 1,
+  // Disallow use of octal escape sequences in string literals,
+  // such as var foo = "Copyright \251";
+  'no-octal-escape': 2,
+  // Disallow use of octal literals
+  'no-octal': 1,
+  // Allow reassignment of function parameters
+  'no-param-reassign': 0,
+  // Disallow use of process.env
+  'no-process-env': 2,
+  // Disallow usage of __proto__ property
+  'no-proto': 2,
+  // Disallow declaring the same variable more than once
+  'no-redeclare': 2,
+  // Disallow use of assignment in return statement
+  'no-return-assign': 2,
+  // Disallow use of javascript: urls.,
+  'no-script-url': 0,
+  // Disallow assignments where both sides are exactly the same
+  'no-self-assign': 2,
+  // Disallow comparisons where both sides are exactly the same
+  'no-self-compare': 2,
+  // Disallow use of comma operator
+  'no-sequences': 1,
+  // Restrict what can be thrown as an exception
+  'no-throw-literal': 1,
+  // Disallow unmodified conditions of loops
+  'no-unmodified-loop-condition': 2,
+  // Disallow usage of expressions in statement position
+  'no-unused-expressions': 1,
+  // Disallow unused labels
+  'no-unused-labels': 2,
+  // Disallow unnecessary .call() and .apply()
+  'no-useless-call': 2,
+  // Disallow unnecessary concatenation of literals or template literals
+  'no-useless-concat': 1,
+  // Disallow use of void operator
+  'no-void': 2,
+  // Disallow usage of configurable warning terms in comments
+  'no-warning-comments': 1,
+  // Disallow use of the with statement
+  'no-with': 2,
+  // Require use of the second argument for parseInt()
+  'radix': 2,
+  // Requires to declare all vars on top of their containing scope
+  'vars-on-top': 0,
+  // Require immediate function invocation to be wrapped in parentheses
+  'wrap-iife': [1, 'inside'],
+  // Require or disallow Yoda conditions
+  'yoda': [1, 'never'],
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/ecmascript-6.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/ecmascript-6.js
@@ -1,0 +1,50 @@
+// see http://eslint.org/docs/rules/#ecmascript-6
+
+module.exports = {
+  // Require braces in arrow function body
+  'arrow-body-style': [2, 'as-needed'],
+  // Require parens in arrow function arguments
+  'arrow-parens': [1, 'always'],
+  // Require space before/after arrow function's arrow
+  'arrow-spacing': [1, {before: true, after: true}],
+  // Verify super() callings in constructors
+  'constructor-super': 2,
+  // Enforce the spacing around the * in generator functions
+  'generator-star-spacing': [1, 'after'],
+  // Disallow modifying variables of class declarations
+  'no-class-assign': 1,
+  // Disallow arrow functions where they could be confused with comparisons
+  'no-confusing-arrow': 2,
+  // Disallow modifying variables that are declared using const
+  'no-const-assign': 2,
+  // Disallow duplicate name in class members
+  'no-dupe-class-members': 2,
+  // Disallow use of the new operator with the Symbol object
+  'no-new-symbol': 2,
+  // Disallow to use this/super before super() calling in constructors.
+  'no-this-before-super': 2,
+  // Disallow unnecessary constructor
+  'no-useless-constructor': 1,
+  // Require let or const instead of var
+  'no-var': 2,
+  // Require method and property shorthand syntax for object literals
+  'object-shorthand': [1, 'always'],
+  // Suggest using arrow functions as callbacks
+  'prefer-arrow-callback': 2,
+  // Suggest using of const declaration for variables that are never modified after declared
+  'prefer-const': 1,
+  // Suggest using the rest parameters instead of arguments
+  'prefer-rest-params': 2,
+  // Suggest using the spread operator instead of .apply()
+  'prefer-spread': 2,
+  // Suggest using Reflect methods where applicable
+  'prefer-reflect': 0,
+  // Suggest using template literals instead of strings concatenation
+  'prefer-template': 1,
+  // Disallow generator functions that do not have yield
+  'require-yield': 2,
+  // Enforce spacing around embedded expressions of template strings
+  'template-curly-spacing': [1, 'never'],
+  // Enforce spacing around the * in yield* expressions
+  'yield-star-spacing': [1, {before: false, after: true}],
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/legacy.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/legacy.js
@@ -1,0 +1,16 @@
+// see http://eslint.org/docs/rules/#legacy
+
+module.exports = {
+  // Specify the maximum depth that blocks can be nested
+  'max-depth': 0,
+  // Specify the maximum length of a line in your program
+  'max-len': 0,
+  // Limits the number of parameters that can be used in the function declaration.
+  'max-params': [1, 10],
+  // Specify the maximum number of statement allowed in a function
+  'max-statements': 0,
+  // Disallow use of bitwise operators
+  'no-bitwise': 0,
+  // Disallow use of unary operators, ++ and --
+  'no-plusplus': 0,
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/node.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/node.js
@@ -1,0 +1,24 @@
+// see http://eslint.org/docs/rules/#nodejs
+
+module.exports = {
+  // enforce return after a callback
+  'callback-return': [1, ['callback', 'cb', 'next']],
+  // disallow require() outside of the top-level module scope
+  'global-require': 0,
+  // Enforces error handling in callbacks
+  'handle-callback-err': [1, '^.*(e|E)rr(or)?$'],
+  // Disallow mixing regular variable and require declarations
+  'no-mixed-requires': 0,
+  // Disallow use of new operator with the require function
+  'no-new-require': 1,
+  // Disallow string concatenation with __dirname and __filename
+  'no-path-concat': 1,
+  // Disallow process.exit()
+  'no-process-exit': 1,
+  // Restrict usage of specified node imports
+  'no-restricted-imports': 0,
+  // Restrict usage of specified node modules
+  'no-restricted-modules': 0,
+  // Disallow use of synchronous methods
+  'no-sync': 1,
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/possible-errors.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/possible-errors.js
@@ -1,0 +1,60 @@
+// see http://eslint.org/docs/rules/#possible-errors
+
+module.exports = {
+  // Disallow or enforce trailing commas
+  'comma-dangle': [1, 'always-multiline'],
+  // Disallow assignment in conditional expressions
+  'no-cond-assign': 2,
+  // Disallow use of console
+  'no-console': 1,
+  // Disallow use of constant expressions in conditions
+  'no-constant-condition': 1,
+  // Disallow control characters in regular expressions
+  'no-control-regex': 2,
+  // Disallow use of debugger
+  'no-debugger': 1,
+  // Disallow duplicate arguments in functions
+  'no-dupe-args': 2,
+  // Disallow duplicate keys when creating object literals
+  'no-dupe-keys': 2,
+  // Disallow a duplicate case label.
+  'no-duplicate-case': 2,
+  // Disallow the use of empty character classes in regular expressions
+  'no-empty-character-class': 2,
+  // Disallow empty statements
+  'no-empty': 1,
+  // Disallow assigning to the exception in a catch block
+  'no-ex-assign': 2,
+  // Disallow double-negation boolean casts in a boolean context
+  'no-extra-boolean-cast': 1,
+  // Disallow unnecessary parentheses
+  'no-extra-parens': 0,
+  // Disallow unnecessary semicolons
+  'no-extra-semi': 1,
+  // Disallow overwriting functions written as function declarations
+  'no-func-assign': 1,
+  // Disallow function or variable declarations in nested blocks
+  'no-inner-declarations': 1,
+  // Disallow invalid regular expression strings in the RegExp constructor
+  'no-invalid-regexp': 2,
+  // Disallow irregular whitespace outside of strings and comments
+  'no-irregular-whitespace': 1,
+  // Disallow negation of the left operand of an in expression
+  'no-negated-in-lhs': 1,
+  // Disallow the use of object properties of the global object (Math and JSON) as functions
+  'no-obj-calls': 2,
+  // Disallow multiple spaces in a regular expression literal
+  'no-regex-spaces': 1,
+  // Disallow sparse arrays
+  'no-sparse-arrays': 1,
+  // Disallow unreachable statements after a return, throw, continue, or break statement
+  'no-unreachable': 2,
+  // Disallow comparisons with the value NaN
+  'use-isnan': 2,
+  // Ensure JSDoc comments are valid
+  'valid-jsdoc': 0,
+  // Ensure that the results of typeof are compared against a valid string
+  'valid-typeof': 2,
+  // Avoid code that looks like two expressions but is actually one
+  'no-unexpected-multiline': 1,
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/react.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/react.js
@@ -1,0 +1,84 @@
+module.exports = {
+  // Prevent missing displayName in a React component definition
+  'react/display-name': [1, {acceptTranspilerName: true}],
+  // Forbid certain propTypes
+  'react/forbid-prop-types': [2, {forbid: ['any', 'array']}],
+  // Enforce boolean attributes notation in JSX
+  'react/jsx-boolean-value': 1,
+  // Validate closing bracket location in JSX
+  'react/jsx-closing-bracket-location': [1, {location: 'tag-aligned'}],
+  // Enforce or disallow spaces inside of curly braces in JSX attributes
+  'react/jsx-curly-spacing': [1, 'never', {allowMultiline: true}],
+  // Enforce or disallow spaces around equal signs in JSX attributes
+  'react/jsx-equals-spacing': [1, 'never'],
+  // Validate props indentation in JSX
+  'react/jsx-indent-props': [1, 2],
+  // Validate JSX indentation
+  'react/jsx-indent': [1, 2],
+  // Validate JSX has key prop when in array or iterator
+  'react/jsx-key': 2,
+  // Limit maximum of props on a single line in JSX
+  'react/jsx-max-props-per-line': 0,
+  // Prevent usage of .bind() and arrow functions in JSX props
+  'jsx-no-bind': 0,
+  // Prevent duplicate props in JSX
+  'react/jsx-no-duplicate-props': 2,
+  // Prevent usage of unwrapped JSX strings
+  'react/jsx-no-literals': 0,
+  // Disallow undeclared variables in JSX
+  'react/jsx-no-undef': 2,
+  // Enforce PascalCase for user-defined JSX components
+  'react/jsx-pascal-case': 2,
+  // Enforce propTypes declarations alphabetical sorting
+  'react/jsx-sort-prop-types': 0,
+  // Enforce props alphabetical sorting
+  'react/jsx-sort-props': 0,
+  // Prevent React to be incorrectly marked as unused
+  'react/jsx-uses-react': 2,
+  // Prevent variables used in JSX to be incorrectly marked as unused
+  'react/jsx-uses-vars': 2,
+  // Prevent usage of dangerous JSX properties
+  'react/no-danger': 1,
+  // Prevent usage of deprecated methods
+  'react/no-deprecated': 2,
+  // Prevent usage of setState in componentDidMount
+  'react/no-did-mount-set-state': 2,
+  // Prevent usage of setState in componentDidUpdate
+  'react/no-did-update-set-state': 2,
+  // Prevent direct mutation of this.state
+  'react/no-direct-mutation-state': 2,
+  // Prevent usage of isMounted
+  'react/no-is-mounted': 2,
+  // Prevent multiple component definition per file
+  'react/no-multi-comp': 0,
+  // Prevent usage of setState
+  'react/no-set-state': 0,
+  // Prevent using string references in ref attribute.
+  'react/no-string-refs': 1,
+  // Prevent usage of unknown DOM property
+  'react/no-unknown-property': 0,
+  // Prevent missing props validation in a React component definition
+  'react/prop-types': 1,
+  // Prevent missing React when using JSX
+  'react/react-in-jsx-scope': 2,
+  // Restrict file extensions that may be required
+  'react/require-extension': [2, {extensions: ['.js']}],
+  // Prevent extra closing tags for components without children
+  'react/self-closing-comp': 1,
+  // Enforce component methods order
+  'react/sort-comp': [
+    1,
+    {
+      order: [
+        'statics',
+        'constructor',
+        'lifecycle',
+        'everything-else',
+        'render',
+      ],
+    },
+  ],
+  // Prevent missing parentheses around multilines JSX
+  'react/wrap-multilines': 1,
+  'react/prefer-es6-class': 2,
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
@@ -1,0 +1,6 @@
+module.exports = {
+  // Requires (or disallows) @flow declarations be present at the top of each file.
+  'shopify/require-flow': [1, 'explicit'],
+  // Requires (or disallows) assignments of binary, boolean-producing expressions to be wrapped in parentheses.
+  'shopify/binary-assignment-parens': [1, 'always'],
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/strict-mode.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/strict-mode.js
@@ -1,0 +1,6 @@
+// http://eslint.org/docs/rules/#strict-mode
+
+module.exports = {
+  // Controls location of Use Strict Directives
+  strict: [2, 'never'],
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/stylistic-issues.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/stylistic-issues.js
@@ -1,0 +1,120 @@
+// see http://eslint.org/docs/rules/#stylistic-issues
+
+module.exports = {
+  // Enforce spacing inside array brackets
+  'array-bracket-spacing': [1, 'never'],
+  // Disallow or enforce spaces inside of single line blocks
+  'block-spacing': [1, 'always'],
+  // Enforce one true brace style
+  'brace-style': [1, '1tbs', {allowSingleLine: true}],
+  // Require camel case names
+  'camelcase': [1, {properties: 'always'}],
+  // Enforce spacing before and after comma
+  'comma-spacing': [1, {before: false, after: true}],
+  // Enforce one true comma style
+  'comma-style': [1, 'last'],
+  // Require or disallow padding inside computed properties
+  'computed-property-spacing': [1, 'never'],
+  // Enforces consistent naming when capturing the current execution context
+  'consistent-this': [1, 'self'],
+  // Enforce newline at the end of file, with no multiple empty lines
+  'eol-last': 1,
+  // Don't require function expressions to have a name
+  'func-names': 0,
+  // Enforces use of function declarations or expressions
+  'func-style': [1, 'declaration'],
+  // Blacklist certain identifiers to prevent them being used
+  'id-blacklist': 0,
+  // This option enforces minimum and maximum identifier lengths (variable names, property names etc.)
+  'id-length': [1, {min: 2, properties: 'always', exceptions: ['x', 'y', 'i', 'j', '_', '$']}],
+  // Require identifiers to match the provided regular expression
+  'id-match': 0,
+  // This option sets a specific tab width for your code
+  'indent': [1, 2],
+  // Specify whether double or single quotes should be used in JSX attributes
+  'jsx-quotes': [1, 'prefer-double'],
+  // Enforces spacing between keys and values in object literal properties
+  'key-spacing': [1, {beforeColon: false, afterColon: true}],
+  // Enforce spacing before and after keywords
+  'keyword-spacing': [1, {before: true, after: true, overrides: {}}],
+  // Disallow mixed "LF" and "CRLF" as linebreaks
+  'linebreak-style': 0,
+  // Enforces empty lines around comments
+  'lines-around-comment': [1, {beforeBlockComment: true}],
+  // Specify the maximum depth callbacks can be nested
+  'max-nested-callbacks': 0,
+  // Require a capital letter for constructors
+  'new-cap': [2, {newIsCap: true}],
+  // Disallow the omission of parentheses when invoking a constructor with no arguments
+  'new-parens': 1,
+  // Allow/disallow an empty newline after var statement
+  'newline-after-var': 0,
+  // Enforce newline after each call when chaining the calls
+  'newline-per-chained-call': [1, {ignoreChainWithDepth: 3}],
+  // Disallow use of the Array constructor
+  'no-array-constructor': 2,
+  // Disallow use of the continue statement
+  'no-continue': 0,
+  // Disallow comments inline after code
+  'no-inline-comments': 0,
+  // Disallow if as the only statement in an else block
+  'no-lonely-if': 1,
+  // Disallow mixed spaces and tabs for indentation
+  'no-mixed-spaces-and-tabs': 1,
+  // Disallow multiple empty lines
+  'no-multiple-empty-lines': 1,
+  // Disallow nested ternary expressions
+  'no-nested-ternary': 1,
+  // Disallow use of the Object constructor
+  'no-new-object': 1,
+  // Disallow space between function identifier and application
+  'no-spaced-func': 1,
+  // Disallow the use of ternary operators
+  'no-ternary': 0,
+  // Disallow trailing whitespace at the end of lines
+  'no-trailing-spaces': 1,
+  // Allow dangling underscores in identifiers
+  'no-underscore-dangle': 0,
+  // Disallow the use of Boolean literals in conditional expressions
+  'no-unneeded-ternary': 1,
+  // Disallow whitespace before properties
+  'no-whitespace-before-property': 2,
+  // Require or disallow padding inside curly braces
+  'object-curly-spacing': [1, 'never'],
+  // Allow or disallow one variable declaration per function
+  'one-var': [1, 'never'],
+  // Require or disallow an newline around variable declarations
+  'one-var-declaration-per-line': [1, 'initializations'],
+  // Require assignment operator shorthand where possible or prohibit it entirely
+  'operator-assignment': [1, 'always'],
+  // Enforce operators to be placed before or after line breaks
+  'operator-linebreak': [1, 'after', {overrides: {'?': 'before', ':': 'before'}}],
+  // Enforce padding within blocks
+  'padded-blocks': 0,
+  // Require quotes around object literal property names
+  'quote-props': [1, 'as-needed'],
+  // Specify whether backticks, double or single quotes should be used
+  'quotes': [1, 'single', 'avoid-escape'],
+  // Enforce spacing before and after semicolons
+  'semi-spacing': [1, {before: false, after: true}],
+  // Require or disallow use of semicolons instead of ASI
+  'semi': [1, 'always'],
+  // Sort import declarations within module
+  'sort-imports': 0,
+  // Sort variables within the same declaration block
+  'sort-vars': 0,
+  // Require or disallow space before blocks
+  'space-before-blocks': [1, 'always'],
+  // Require or disallow space before function opening parenthesis
+  'space-before-function-paren': [1, 'never'],
+  // Require or disallow spaces inside parentheses
+  'space-in-parens': [1, 'never'],
+  // Require spaces around operators
+  'space-infix-ops': 1,
+  // Require or disallow spaces before/after unary operators (words on by default, nonwords)
+  'space-unary-ops': [1, {words: true, nonwords: false}],
+  // Require or disallow a space immediately following the // or /* in a comment
+  'spaced-comment': [1, 'always'],
+  // Require regex literals to be wrapped in parentheses
+  'wrap-regex': 0,
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/variables.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/variables.js
@@ -1,0 +1,26 @@
+// see http://eslint.org/docs/rules/#variables
+
+module.exports = {
+  // enforce or disallow variable initializations at definition
+  'init-declarations': 0,
+  // Disallow the catch clause parameter name being the same as a variable in the outer scope
+  'no-catch-shadow': 2,
+  // Disallow deletion of variables
+  'no-delete-var': 2,
+  // Disallow labels that share a name with a variable
+  'no-label-var': 2,
+  // Disallow shadowing of names such as arguments
+  'no-shadow-restricted-names': 2,
+  // Disallow declaration of variables already declared in the outer scope
+  'no-shadow': 2,
+  // Disallow use of undefined when initializing variables
+  'no-undef-init': 2,
+  // Disallow use of undeclared variables unless mentioned in a /*global */ block
+  'no-undef': 2,
+  // Disallow use of undefined variable
+  'no-undefined': 2,
+  // Disallow declaration of variables that are not used in the code
+  'no-unused-vars': 1,
+  // Disallow use of variables before they are defined
+  'no-use-before-define': [2, 'nofunc'],
+};

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -1,10 +1,12 @@
 {
   "name": "eslint-plugin-shopify",
   "version": "7.0.0",
-  "description": "Shopify-specific ESLint rules.",
+  "description": "Shopify’s ESLint rules and configs.",
   "keywords": [
     "eslint",
+    "eslintconfig",
     "eslintplugin",
+    "eslint-config",
     "eslint-plugin"
   ],
   "author": "Chris Sauve <chris.sauve@shopify.com>",
@@ -30,5 +32,10 @@
   },
   "peerDependencies": {
     "eslint": ">=1.0.0"
+  },
+  "dependencies": {
+    "merge": "^1.2.0",
+    "babel-eslint": "^4.1.8",
+    "eslint-plugin-react": "^3.16.1"
   }
 }

--- a/packages/generator-eslint-shopify/.eslintrc
+++ b/packages/generator-eslint-shopify/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "shopify",
+  "extends": "plugin:shopify/react",
   "env": {
     "es6": true,
     "node": true

--- a/packages/generator-eslint-shopify/.eslintrc
+++ b/packages/generator-eslint-shopify/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "plugin:shopify/react",
+  "extends": "plugin:shopify/esnext",
   "env": {
     "es6": true,
     "node": true

--- a/packages/generator-eslint-shopify/package.json
+++ b/packages/generator-eslint-shopify/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "generator-eslint-config": "^1.1.0",
+    "generator-eslint-config": "^1.2.0",
     "yeoman-generator": "^0.22.2",
     "yosay": "^1.1.0"
   }

--- a/packages/generator-eslint-shopify/src/app/index.js
+++ b/packages/generator-eslint-shopify/src/app/index.js
@@ -9,13 +9,13 @@ module.exports = class ESLintShopifyGenerator extends BaseGenerator {
     this.option('react', {
       type: Boolean,
       required: false,
-      desc: 'Installs the React plugin and rule set.',
+      desc: 'Uses the React configuration.',
     });
 
     this.option('es5', {
       type: Boolean,
       required: false,
-      desc: 'Installs the ES5 rules only.',
+      desc: 'Uses the ES5 configuration.',
     });
   }
 
@@ -63,19 +63,16 @@ module.exports = class ESLintShopifyGenerator extends BaseGenerator {
   defaults() {
     const {props, options} = this;
 
-    const plugins = ['shopify'];
-    if (props.react) { plugins.push('react'); }
-
-    let extendsConfig = 'shopify';
-    if (props.react) { extendsConfig = 'shopify/react'; }
-    if (props.es5) { extendsConfig = 'shopify/es5'; }
+    let extendsConfig = 'plugin:shopify/esnext';
+    if (props.react) { extendsConfig = 'plugin:shopify/react'; }
+    if (props.es5) { extendsConfig = 'plugin:shopify/es5'; }
 
     const eslintOptions = {
       extends: extendsConfig,
-      plugins,
+      plugins: [],
       skipInstall: options.skipInstall,
       skipWelcomeMessage: true,
-      babel: true,
+      babel: false, // handled by the plugin
     };
 
     this.composeWith(

--- a/packages/generator-eslint-shopify/test/src/app/index.test.js
+++ b/packages/generator-eslint-shopify/test/src/app/index.test.js
@@ -25,8 +25,7 @@ describe('generator-eslint-shopify:app', () => {
 
     it('sets the Shopify config and plugin', () => {
       assert.jsonFileContent('.eslintrc', {
-        extends: 'shopify',
-        plugins: ['shopify'],
+        extends: 'plugin:shopify/esnext',
       });
     });
   });
@@ -41,8 +40,7 @@ describe('generator-eslint-shopify:app', () => {
 
     it('sets the React Shopify config and plugin', () => {
       assert.jsonFileContent('.eslintrc', {
-        extends: 'shopify/react',
-        plugins: ['shopify', 'react'],
+        extends: 'plugin:shopify/react',
       });
     });
   });
@@ -57,7 +55,7 @@ describe('generator-eslint-shopify:app', () => {
 
     it('sets the ES5 Shopify config', () => {
       assert.jsonFileContent('.eslintrc', {
-        extends: 'shopify/es5',
+        extends: 'plugin:shopify/es5',
       });
     });
   });


### PR DESCRIPTION
This PR uses the new features in ESLint 2.0 to update the `eslint-plugin-shopify` to serve our shared config in addition to our custom rules. It also moves the react plugin and babel parser to be dependencies of the plugin. What this means is that installation is now considerably simpler — you just need to `npm install eslint eslint-plugin-shopify --save-dev` and add an `.eslintrc` file that points to the plugin's configs.

As mentioned in the previous PR, the config name (in the `eslintrc "extends"` field)  is a bit more complex — `shopify` becomes `plugin:shopify/esnext`, `shopify/react` becomes `plugin:shopify/react`, and `shopify/es5` becomes `plugin:shopify/es5`. A small price to pay for simpler setup and package structure, I think. The generator has also been updated to generate these new config options.

After this is merged I will bump to `8.0.0` and delete the `eslint-config-shopify` package, since it won't be updated anymore.

cc/ @Shopify/fed @bouk 