### PR TITLE
Put all dev dependencies at the root

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
 
 test:
   override:
-    - script/test
+    - script/check

--- a/package.json
+++ b/package.json
@@ -4,11 +4,16 @@
   "description": "The home for all things JavaScript at Shopify.",
   "scripts": {
     "lint": "eslint . --max-warnings 0",
-    "test": "cd packages/eslint-plugin-shopify && npm test && cd ../generator-eslint-shopify && npm test && cd ../shopify-codemod && npm test && cd ../..",
+    "test": "script/test",
     "check": "npm run lint && npm test",
     "setup": "npm install && lerna bootstrap",
     "updated": "lerna updated",
     "publish-all": "npm run check && lerna publish"
+  },
+  "babel": {
+    "presets": [
+      "shopify"
+    ]
   },
   "bugs": {
     "url": "https://github.com/Shopify/javascript/issues"
@@ -18,8 +23,27 @@
   "author": "Chris Sauve <chrismsauve@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "lerna": "^1.1.1",
+    "shelljs": "^0.6.0",
+
     "eslint": "2.2.0",
     "eslint-plugin-shopify": "file:./packages/eslint-plugin-shopify",
-    "lerna": "^1.1.1"
+
+    "babel-core": "^6.7.0",
+    "babel-cli": "^6.6.4",
+    "babel-preset-shopify": "file:./packages/babel-preset-shopify",
+
+    "mocha": "^2.4.5",
+    "chai": "^3.5.0",
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0",
+    "isparta": "^4.0.0",
+    "istanbul": "^0.4.2",
+    "coveralls": "^2.11.8",
+
+    "yeoman-assert": "^2.1.1",
+    "yeoman-test": "^1.1.0",
+
+    "jscodeshift": "^0.3.16"
   }
 }

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -11,15 +11,10 @@
   ],
   "author": "Chris Sauve <chris.sauve@shopify.com>",
   "scripts": {
-    "test:cover": "istanbul cover --dir reports/coverage node_modules/.bin/_mocha tests/ --recursive -- --reporter dot",
-    "test": "mocha tests/ --recursive"
+    "test": "../../node_modules/.bin/mocha tests/ --recursive --reporter spec",
+    "test:watch": "npm test -- --watch --reporter min",
+    "test:cover": "../../node_modules/.bin/istanbul cover --dir coverage ../../node_modules/.bin/_mocha -- --recursive tests/"
   },
-  "files": [
-    "LICENSE",
-    "README.md",
-    "index.js",
-    "lib"
-  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Shopify/javascript/issues"
@@ -28,10 +23,6 @@
   "repository": "https://github.com/Shopify/javascript/tree/master/packages/eslint-plugin-shopify",
   "eslintConfig": {
     "extends": "plugin:shopify/es5"
-  },
-  "devDependencies": {
-    "istanbul": "^0.3.20",
-    "mocha": "^2.3.2"
   },
   "peerDependencies": {
     "eslint": ">=2.2.0"

--- a/packages/generator-eslint-shopify/package.json
+++ b/packages/generator-eslint-shopify/package.json
@@ -6,17 +6,13 @@
   "jsnext:main": "src/app/index.js",
   "scripts": {
     "clean": "rm -rf generators/ coverage/",
-    "build:lib": "babel src --ignore **/templates/**.js --out-dir generators",
+    "build:lib": "../../node_modules/.bin/babel src --ignore **/templates/**.js --out-dir generators",
     "build": "npm run clean && npm run build:lib",
     "preversion": "npm run clean && npm run test",
     "prepublish": "npm run build",
-    "test": "mocha test/ --recursive --compilers js:babel-core/register --reporter spec",
+    "test": "../../node_modules/.bin/mocha test/ --recursive --compilers js:babel-core/register --reporter spec",
     "test:watch": "npm test -- --watch --reporter min"
   },
-  "files": [
-    "src",
-    "generators"
-  ],
   "keywords": [
     "yeoman",
     "yeoman-generator",
@@ -33,12 +29,6 @@
   },
   "homepage": "https://github.com/Shopify/javascript/tree/master/packages/generator-eslint-shopify",
   "repository": "https://github.com/Shopify/javascript/tree/master/packages/generator-eslint-shopify",
-  "babel": {
-    "presets": [
-      "shopify"
-    ],
-    "sourceMaps": true
-  },
   "eslintConfig": {
     "extends": "plugin:shopify/esnext",
     "env": {
@@ -48,19 +38,6 @@
     "rules": {
       "shopify/require-flow": 0
     }
-  },
-  "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-core": "^6.3.26",
-    "babel-preset-shopify": "file:../babel-preset-shopify",
-    "chai": "^3.4.1",
-    "coveralls": "^2.11.6",
-    "isparta": "^4.0.0",
-    "mocha": "^2.3.4",
-    "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0",
-    "yeoman-assert": "^2.1.1",
-    "yeoman-test": "^1.0.0"
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/packages/shopify-codemod/package.json
+++ b/packages/shopify-codemod/package.json
@@ -6,29 +6,20 @@
   "repository": "https://github.com/Shopify/javascript/tree/master/packages/shopify-codemod",
   "main": "transforms/index.js",
   "scripts": {
-    "test": "NODE_PATH=./transforms:./test:$NODE_PATH mocha 'test/**/*.test.js' --compilers js:babel-core/register",
-    "test:watch": "npm run test -- --watch --reporter dot",
-    "test:cover": "NODE_PATH=$NODE_PATH:./transforms:./test babel-node $(npm bin)/isparta cover --root transforms/ --reporter text --reporter html $(npm bin)/_mocha -- --reporter spec test/**/*.test.js",
+    "test": "NODE_PATH=./transforms:./test:$NODE_PATH ../../node_modules/.bin/mocha 'test/**/*.test.js' --compilers js:babel-core/register",
+    "test:watch": "npm run test -- --watch --reporter min",
+    "test:cover": "NODE_PATH=$NODE_PATH:./transforms:./test ../../node_modules/.bin/babel-node ../../node_modules/.bin/isparta cover --root transforms/ --reporter text --reporter html ../../node_modules/.bin/_mocha -- --reporter spec test/**/*.test.js",
     "clean": "rm -rf coverage/",
     "prepublish": "npm test"
   },
-  "babel": {
-    "presets": [
-      "shopify"
-    ]
-  },
+  "keywords": [
+    "codemod"
+  ],
   "eslintConfig": {
     "extends": "plugin:shopify/esnext"
   },
   "author": "Chris Sauve <chrismsauve@gmail.com>",
   "license": "MIT",
-  "devDependencies": {
-    "babel-core": "^6.7.2",
-    "chai": "^3.5.0",
-    "isparta": "^4.0.0",
-    "jscodeshift": "^0.3.16",
-    "mocha": "^2.4.5"
-  },
   "dependencies": {
     "babel-preset-shopify": "latest"
   }

--- a/packages/shopify-codemod/transforms/constant-function-expression-to-statement.js
+++ b/packages/shopify-codemod/transforms/constant-function-expression-to-statement.js
@@ -1,8 +1,9 @@
-export default function constantFunctionValueToStatement(file, api, options) {
-  const j = api.jscodeshift;
-  const printOptions = options.printOptions || {quote: 'single'};
-
-  return j(file.source)
+export default function constantFunctionValueToStatement(
+  {source},
+  {jscodeshift: j},
+  {printOptions = {quote: 'single'}}
+) {
+  return j(source)
     .find(j.VariableDeclaration, (path) => j.match(path, {
       kind: 'const',
       declarations: [{

--- a/packages/shopify-codemod/transforms/function-to-arrow.js
+++ b/packages/shopify-codemod/transforms/function-to-arrow.js
@@ -1,16 +1,18 @@
-export default function functionToArrow(file, api, options) {
-  const j = api.jscodeshift;
-  const printOptions = options.printOptions || {quote: 'single'};
-
-  return j(file.source)
+export default function functionToArrow(
+  {source},
+  {jscodeshift: j},
+  {printOptions = {quote: 'single'}}
+) {
+  return j(source)
     .find(j.FunctionExpression)
     .filter((path) => j(path).find(j.ThisExpression).size() === 0)
-    .replaceWith((path) => {
-      const {params} = path.node;
-      let body = path.node.body;
+    .replaceWith(({node}) => {
+      const {params} = node;
+      let {body} = node;
+      const originalBody = body.body;
       // If there is just a single ReturnStatement, just replace the whole body.
-      if (body.body.length === 1 && body.body[0].type === 'ReturnStatement') {
-        body = body.body[0].argument;
+      if (originalBody.length === 1 && originalBody[0].type === 'ReturnStatement') {
+        body = originalBody[0].argument;
       }
       return j.arrowFunctionExpression(params, body, body.type !== 'BlockStatement');
     })

--- a/packages/shopify-codemod/transforms/index.js
+++ b/packages/shopify-codemod/transforms/index.js
@@ -1,1 +1,4 @@
+export {default as functionToArrow} from './function-to-arrow';
 export {default as mochaContextToClosure} from './mocha-context-to-closure';
+export {default as ternaryStatementToIfStatement} from './ternary-statement-to-if-statement';
+export {default as constantFunctionValueToStatement} from './constant-function-expression-to-statement';

--- a/packages/shopify-codemod/transforms/mocha-context-to-closure.js
+++ b/packages/shopify-codemod/transforms/mocha-context-to-closure.js
@@ -1,4 +1,8 @@
-export default function mochaContextToClosure({source}, {jscodeshift: j}, {printOptions = {}}) {
+export default function mochaContextToClosure(
+  {source},
+  {jscodeshift: j},
+  {printOptions = {quote: 'single'}}
+) {
   let currentContext;
   const root = j(source);
 

--- a/packages/shopify-codemod/transforms/ternary-statement-to-if-statement.js
+++ b/packages/shopify-codemod/transforms/ternary-statement-to-if-statement.js
@@ -1,8 +1,9 @@
-export default function ternaryStatementToIfStatement(file, api, options) {
-  const j = api.jscodeshift;
-  const printOptions = options.printOptions || {quote: 'single'};
-
-  return j(file.source)
+export default function ternaryStatementToIfStatement(
+  {source},
+  {jscodeshift: j},
+  {printOptions = {quote: 'single'}}
+) {
+  return j(source)
     .find(j.ConditionalExpression)
     .filter((path) => path.parent.node.type === 'ExpressionStatement' || path.parent.node.type === 'ReturnStatement')
     .map((path) => path.parent)

--- a/script/check
+++ b/script/check
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ex
+npm run check

--- a/script/test
+++ b/script/test
@@ -1,3 +1,16 @@
-#!/bin/bash
-set -ex
-npm run check
+#!/usr/bin/env node
+
+var path = require('path');
+var shell = require('shelljs');
+var execSync = require('child_process').execSync;
+var packageRoot = path.join(__dirname, '../packages');
+
+test('shopify-codemod');
+test('generator-eslint-shopify');
+test('eslint-plugin-shopify');
+
+function test(packageName) {
+  var packagePath = path.join(packageRoot, packageName);
+  shell.cd(packagePath);
+  return execSync('npm test', {stdio: 'inherit'});
+}


### PR DESCRIPTION
This PR moves all the dev dependencies to the root. This makes it so we don't have to download multiple versions of some enormous packages (Babel is particularly bad on this). The tests scripts were all updated so they can be run from the individual packages, as well.

cc/ @bouk