### PR TITLE
Transform conditional assignments to `if` blocks

### DIFF
--- a/packages/shopify-codemod/README.md
+++ b/packages/shopify-codemod/README.md
@@ -1,4 +1,4 @@
-# shopify-codemods
+# shopify-codemod
 
 This repository contains a collection of Codemods written with [JSCodeshift](https://github.com/facebook/jscodeshift) that will help update our old, crusty JavaScript to nice, clean JavaScript.
 
@@ -11,12 +11,32 @@ This repository contains a collection of Codemods written with [JSCodeshift](htt
 
 ## Included Transforms
 
+### `conditional-assign-to-if-statement`
+
+Changes conditional assignment of default values to if statements (see [`no-unused-expressions`.](http://eslint.org/docs/rules/no-unused-expressions))
+
+```sh
+jscodeshift -t shopify-codemod/transforms/conditional-assign-to-if-statement <file>
+```
+
+#### Example
+
+```js
+foo || (foo = 'bar');
+
+// BECOMES:
+
+if (!foo) {
+  foo = 'bar';
+};
+```
+
 ### `constant-function-expression-to-statement`
 
 Changes constant function expression declarations to a statement.
 
 ```sh
-jscodeshift -t shopify-codemods/transforms/constant-function-expression-to-statement <file>
+jscodeshift -t shopify-codemod/transforms/constant-function-expression-to-statement <file>
 ```
 
 #### Example
@@ -38,7 +58,7 @@ function a() {
 Changes function expressions to arrow functions, where possible.
 
 ```sh
-jscodeshift -t shopify-codemods/transforms/function-to-arrow <file>
+jscodeshift -t shopify-codemod/transforms/function-to-arrow <file>
 ```
 
 #### Example
@@ -102,7 +122,7 @@ console.log(UIList);
 Transforms Mocha tests that use `this` to store context shared between tests to use closure variables instead.
 
 ```sh
-jscodeshift -t shopify-codemods/transforms/mocha-context-to-closure <file>
+jscodeshift -t shopify-codemod/transforms/mocha-context-to-closure <file>
 ```
 
 #### Example
@@ -137,7 +157,7 @@ describe(() => {
 Changes CoffeeScript-translated test files to remove useless return statements.
 
 ```sh
-jscodeshift -t shopify-codemods/transforms/remove-useless-return-from-test <file>
+jscodeshift -t shopify-codemod/transforms/remove-useless-return-from-test <file>
 ```
 
 #### Example
@@ -213,7 +233,7 @@ suite('a', () => {
 Changes ternary statement expressions to if statements.
 
 ```sh
-jscodeshift -t shopify-codemods/transforms/ternary-statement-to-if-statement <file>
+jscodeshift -t shopify-codemod/transforms/ternary-statement-to-if-statement <file>
 ```
 
 #### Example

--- a/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/assign-to-other-identifier.input.js
+++ b/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/assign-to-other-identifier.input.js
@@ -1,0 +1,7 @@
+this.foo || (this.bar = 'lol');
+self.foo || (self.bar = 'lols');
+foo || (bar = 'lols');
+
+this.foo && (this.bar = 'lol');
+self.foo && (self.bar = 'lol');
+foo && (bar = 'lol');

--- a/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/assign-to-other-identifier.output.js
+++ b/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/assign-to-other-identifier.output.js
@@ -1,0 +1,23 @@
+if (!this.foo) {
+  this.bar = 'lol';
+}
+
+if (!self.foo) {
+  self.bar = 'lols';
+}
+
+if (!foo) {
+  bar = 'lols';
+}
+
+if (this.foo) {
+  this.bar = 'lol';
+}
+
+if (self.foo) {
+  self.bar = 'lol';
+}
+
+if (foo) {
+  bar = 'lol';
+}

--- a/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/conditional-and-assignments.input.js
+++ b/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/conditional-and-assignments.input.js
@@ -1,0 +1,7 @@
+foo && (foo = 'foobar');
+
+foo.bar && (foo.bar = 'foobar');
+
+foo.bar.baz && (foo.bar.baz = 'qux');
+
+this.bar && (this.bar = 'foobar');

--- a/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/conditional-and-assignments.output.js
+++ b/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/conditional-and-assignments.output.js
@@ -1,0 +1,15 @@
+if (foo) {
+  foo = 'foobar';
+}
+
+if (foo.bar) {
+  foo.bar = 'foobar';
+}
+
+if (foo.bar.baz) {
+  foo.bar.baz = 'qux';
+}
+
+if (this.bar) {
+  this.bar = 'foobar';
+}

--- a/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/conditional-or-assignments.input.js
+++ b/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/conditional-or-assignments.input.js
@@ -1,0 +1,7 @@
+foo || (foo = 'foobar');
+
+foo.bar || (foo.bar = 'foobar');
+
+foo.bar.baz || (foo.bar.baz = 'qux');
+
+this.bar || (this.bar = 'foobar');

--- a/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/conditional-or-assignments.output.js
+++ b/packages/shopify-codemod/test/fixtures/conditional-assign-to-if-statement/conditional-or-assignments.output.js
@@ -1,0 +1,15 @@
+if (!foo) {
+  foo = 'foobar';
+}
+
+if (!foo.bar) {
+  foo.bar = 'foobar';
+}
+
+if (!foo.bar.baz) {
+  foo.bar.baz = 'qux';
+}
+
+if (!this.bar) {
+  this.bar = 'foobar';
+}

--- a/packages/shopify-codemod/test/transforms/conditional-assign-to-if-statement.test.js
+++ b/packages/shopify-codemod/test/transforms/conditional-assign-to-if-statement.test.js
@@ -1,0 +1,16 @@
+import 'test-helper';
+import conditionalAssignToIfStatement from 'conditional-assign-to-if-statement';
+
+describe('conditionalAssignToIfStatement', () => {
+  it('transforms or assignments', () => {
+    expect(conditionalAssignToIfStatement).to.transform('conditional-assign-to-if-statement/conditional-or-assignments');
+  });
+
+  it('transforms and assignments', () => {
+    expect(conditionalAssignToIfStatement).to.transform('conditional-assign-to-if-statement/conditional-and-assignments');
+  });
+
+  it('updates assignment target when condition variable differs', () => {
+    expect(conditionalAssignToIfStatement).to.transform('conditional-assign-to-if-statement/assign-to-other-identifier');
+  });
+});

--- a/packages/shopify-codemod/transforms/conditional-assign-to-if-statement.js
+++ b/packages/shopify-codemod/transforms/conditional-assign-to-if-statement.js
@@ -1,0 +1,19 @@
+export default function conditionalAssignToIfStatement({source}, {jscodeshift: j}, {printOptions = {quote: 'single'}}) {
+  return j(source)
+    .find(j.ExpressionStatement, {
+      expression: {
+        type: j.LogicalExpression.name,
+        operator: (op) => ['&&', '||'].indexOf(op) >= 0,
+      },
+    })
+    .replaceWith(({node: {expression: logicalExpression}}) => {
+      const {operator, left: originalCondition, right: assignment} = logicalExpression;
+      const newCondition = (operator === '||' ? j.unaryExpression('!', originalCondition) : originalCondition);
+      const assignmentBlock = j.blockStatement([
+        j.expressionStatement(assignment),
+      ]);
+
+      return j.ifStatement(newCondition, assignmentBlock);
+    })
+    .toSource(printOptions);
+}


### PR DESCRIPTION
This transforms vanilla expression statements.  Conditional assignments that return a value, or that immediately call into the assigned value will be handled by subsequent PRs.

/cc @lemonmade @bouk 