### PR TITLE
Add mochaContextToGlobalReferences codemod

### DIFF
--- a/packages/shopify-codemod/README.md
+++ b/packages/shopify-codemod/README.md
@@ -11,6 +11,70 @@ This repository contains a collection of Codemods written with [JSCodeshift](htt
 
 ## Included Transforms
 
+### `mocha-context-to-global-reference`
+
+Removes any specified properties that are injected into the mocha test context (that is, that are referenced using `this` in your tests) to appropriate globals instead. This is particularly useful for making any sinon-injected properties reference a global sinon sandbox. Note that you must provide a `testContextToGlobals` option for your transform, with keys that indicate the proper global to reference, referencing an object with a `properties` key that is an array of contextual properties to look for, and an optional `replace` key that indicates that the entire property should be renamed.
+
+```sh
+jscodeshift -t shopify-codemod/transforms/mocha-context-to-global-reference <file>
+```
+
+#### Example
+
+```js
+
+// WITH OPTIONS:
+//
+// {
+//   testContextToGlobals: {
+//     sinon: {
+//       properties: ['spy', 'stub'],
+//     },
+//   },
+// }
+
+describe('foo', function() {
+  setup(function() {
+    this.mySpy = this.spy();
+    this.myStub = this.stub(someObj, someProp);
+  });
+});
+
+// BECOMES:
+
+describe('foo', function() {
+  setup(function() {
+    this.mySpy = sinon.spy();
+    this.myStub = sinon.stub(someObj, someProp);
+  });
+});
+
+// AND WITH OPTIONS:
+//
+// {
+//   testContextToGlobals: {
+//     testClock: {
+//       properties: ['clock'],
+//       replace: true,
+//     },
+//   },
+// }
+
+describe('bar', function() {
+  setup(function() {
+    this.clock.setTime(Date.now());
+  });
+});
+
+// BECOMES:
+
+describe('bar', function() {
+  setup(function() {
+    testClock.setTime(Date.now());
+  });
+});
+```
+
 ### `conditional-assign-to-if-statement`
 
 Changes conditional assignment of default values to if statements (see [`no-unused-expressions`.](http://eslint.org/docs/rules/no-unused-expressions))
@@ -28,7 +92,7 @@ foo || (foo = 'bar');
 
 if (!foo) {
   foo = 'bar';
-};
+}
 ```
 
 ### `constant-function-expression-to-statement`

--- a/packages/shopify-codemod/test/fixtures/mocha-context-to-global-references/rename.input.js
+++ b/packages/shopify-codemod/test/fixtures/mocha-context-to-global-references/rename.input.js
@@ -1,0 +1,17 @@
+suite('test', function() {
+  afterEach(function() {
+    this.stub(foo, 'bar');
+  });
+
+  before(function() {
+    this.testSpy = this.spy();
+  });
+
+  setup(function() {
+    requests = this.server.requests;
+  });
+
+  it('works', function() {
+    this.server.requests.forEach(() => assert.ok(request));
+  });
+});

--- a/packages/shopify-codemod/test/fixtures/mocha-context-to-global-references/rename.output.js
+++ b/packages/shopify-codemod/test/fixtures/mocha-context-to-global-references/rename.output.js
@@ -1,0 +1,17 @@
+suite('test', function() {
+  afterEach(function() {
+    sinon.stub(foo, 'bar');
+  });
+
+  before(function() {
+    this.testSpy = sinon.spy();
+  });
+
+  setup(function() {
+    requests = sinon.server.requests;
+  });
+
+  it('works', function() {
+    sinon.server.requests.forEach(() => assert.ok(request));
+  });
+});

--- a/packages/shopify-codemod/test/fixtures/mocha-context-to-global-references/replace.input.js
+++ b/packages/shopify-codemod/test/fixtures/mocha-context-to-global-references/replace.input.js
@@ -1,0 +1,14 @@
+suite('test', function() {
+  beforeEach(function() {
+    this.clock.setTime(Date.now());
+    this.shouldBeReplaced = true;
+    this.mustBeReplaced = 'yes';
+    this.notReplaced = true;
+  });
+
+  context('context', function() {
+    it('does not mess up', function() {
+      somethingElse.clock = "don't touch";
+    });
+  });
+});

--- a/packages/shopify-codemod/test/fixtures/mocha-context-to-global-references/replace.output.js
+++ b/packages/shopify-codemod/test/fixtures/mocha-context-to-global-references/replace.output.js
@@ -1,0 +1,14 @@
+suite('test', function() {
+  beforeEach(function() {
+    testClock.setTime(Date.now());
+    testGlobal = true;
+    testGlobal = 'yes';
+    this.notReplaced = true;
+  });
+
+  context('context', function() {
+    it('does not mess up', function() {
+      somethingElse.clock = "don't touch";
+    });
+  });
+});

--- a/packages/shopify-codemod/test/transforms/mocha-context-to-global-references.test.js
+++ b/packages/shopify-codemod/test/transforms/mocha-context-to-global-references.test.js
@@ -1,0 +1,26 @@
+import 'test-helper';
+import mochaContextToGlobalReferences from 'mocha-context-to-global-references';
+
+describe('mochaContextToGlobalReferences', () => {
+  it('replaces a contextual reference to a global reference', () => {
+    expect(mochaContextToGlobalReferences).to.transform('mocha-context-to-global-references/replace', {
+      testContextToGlobals: {
+        testClock: {
+          properties: ['clock'],
+          replace: true,
+        },
+
+        testGlobal: {
+          properties: ['shouldBeReplaced', 'mustBeReplaced'],
+          replace: true,
+        }
+      }
+    });
+
+    expect(mochaContextToGlobalReferences).to.transform('mocha-context-to-global-references/rename', {
+      testContextToGlobals: {
+        sinon: {properties: ['spy', 'stub', 'server']},
+      }
+    });
+  });
+});

--- a/packages/shopify-codemod/test/transforms/mocha-context-to-global-references.test.js
+++ b/packages/shopify-codemod/test/transforms/mocha-context-to-global-references.test.js
@@ -2,6 +2,14 @@ import 'test-helper';
 import mochaContextToGlobalReferences from 'mocha-context-to-global-references';
 
 describe('mochaContextToGlobalReferences', () => {
+  it('renames the member expression to use a test global', () => {
+    expect(mochaContextToGlobalReferences).to.transform('mocha-context-to-global-references/rename', {
+      testContextToGlobals: {
+        sinon: {properties: ['spy', 'stub', 'server']},
+      }
+    });
+  });
+
   it('replaces a contextual reference to a global reference', () => {
     expect(mochaContextToGlobalReferences).to.transform('mocha-context-to-global-references/replace', {
       testContextToGlobals: {
@@ -14,12 +22,6 @@ describe('mochaContextToGlobalReferences', () => {
           properties: ['shouldBeReplaced', 'mustBeReplaced'],
           replace: true,
         }
-      }
-    });
-
-    expect(mochaContextToGlobalReferences).to.transform('mocha-context-to-global-references/rename', {
-      testContextToGlobals: {
-        sinon: {properties: ['spy', 'stub', 'server']},
       }
     });
   });

--- a/packages/shopify-codemod/test/transforms/mocha-context-to-global-references.test.js
+++ b/packages/shopify-codemod/test/transforms/mocha-context-to-global-references.test.js
@@ -26,4 +26,3 @@ describe('mochaContextToGlobalReferences', () => {
     });
   });
 });
-  

--- a/packages/shopify-codemod/test/transforms/mocha-context-to-global-references.test.js
+++ b/packages/shopify-codemod/test/transforms/mocha-context-to-global-references.test.js
@@ -6,7 +6,7 @@ describe('mochaContextToGlobalReferences', () => {
     expect(mochaContextToGlobalReferences).to.transform('mocha-context-to-global-references/rename', {
       testContextToGlobals: {
         sinon: {properties: ['spy', 'stub', 'server']},
-      }
+      },
     });
   });
 
@@ -21,8 +21,9 @@ describe('mochaContextToGlobalReferences', () => {
         testGlobal: {
           properties: ['shouldBeReplaced', 'mustBeReplaced'],
           replace: true,
-        }
-      }
+        },
+      },
     });
   });
 });
+  

--- a/packages/shopify-codemod/transforms/mocha-context-to-global-references.js
+++ b/packages/shopify-codemod/transforms/mocha-context-to-global-references.js
@@ -1,0 +1,50 @@
+import {MOCHA_FUNCTIONS} from './utils';
+
+export default function removeUselessReturnFromTest(
+  {source},
+  {jscodeshift: j},
+  {
+    printOptions = {},
+    testContextToGlobals = {},
+  }
+) {
+  const propMapping = Object.keys(testContextToGlobals).reduce((map, testGlobal) => {
+    const testGlobalDetails = testContextToGlobals[testGlobal];
+    testGlobalDetails.properties.forEach((prop) => {
+      map[prop] = {identifier: j.identifier(testGlobal), replace: Boolean(testGlobalDetails.replace)};
+    });
+    return map;
+  }, {});
+
+  return j(source)
+    .find(j.CallExpression, {
+      callee: {
+        type: 'Identifier',
+        name: (name) => MOCHA_FUNCTIONS.has(name),
+      },
+    })
+    .forEach((path) => {
+      j(path)
+        .find(j.MemberExpression, {
+          object: {
+            type: 'ThisExpression',
+          },
+          property: {
+            type: 'Identifier',
+            name: (name) => propMapping.hasOwnProperty(name),
+          },
+        })
+        .replaceWith((memberPath) => {
+          const propDetails = propMapping[memberPath.get('property').node.name];
+          if (propDetails.replace) {
+            return propDetails.identifier;
+          } else {
+            return j.memberExpression(
+              propDetails.identifier,
+              memberPath.get('property').node
+            );
+          }
+        });
+    })
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/remove-useless-return-from-test.js
+++ b/packages/shopify-codemod/transforms/remove-useless-return-from-test.js
@@ -1,25 +1,4 @@
-// from https://github.com/sindresorhus/globals/blob/1e9ebc39828b92bd5c8ec7dc7bb07d62f2fb0153/globals.json#L852
-const FUNCTIONS = [
-  'after',
-  'afterEach',
-  'before',
-  'beforeEach',
-  'context',
-  'describe',
-  'it',
-  'mocha',
-  'setup',
-  'specify',
-  'suite',
-  'suiteSetup',
-  'suiteTeardown',
-  'teardown',
-  'test',
-  'xcontext',
-  'xdescribe',
-  'xit',
-  'xspecify',
-];
+import {MOCHA_FUNCTIONS} from './utils';
 
 export default function removeUselessReturnFromTest({source}, {jscodeshift: j}, {printOptions = {}}) {
   function matchLast(matcher) {
@@ -30,7 +9,7 @@ export default function removeUselessReturnFromTest({source}, {jscodeshift: j}, 
     .find(j.CallExpression, {
       callee: {
         type: 'Identifier',
-        name: (name) => FUNCTIONS.indexOf(name) >= 0,
+        name: (name) => MOCHA_FUNCTIONS.has(name),
       },
       arguments: matchLast({
         type: (type) => type === 'ArrowFunctionExpression' || type === 'FunctionExpression',

--- a/packages/shopify-codemod/transforms/utils.js
+++ b/packages/shopify-codemod/transforms/utils.js
@@ -22,3 +22,26 @@ export function insertAfterDirectives(body, newNode) {
   body.splice(i, 0, newNode);
   return body;
 }
+
+// from https://github.com/sindresorhus/globals/blob/1e9ebc39828b92bd5c8ec7dc7bb07d62f2fb0153/globals.json#L852
+export const MOCHA_FUNCTIONS = new Set([
+  'after',
+  'afterEach',
+  'before',
+  'beforeEach',
+  'context',
+  'describe',
+  'it',
+  'mocha',
+  'setup',
+  'specify',
+  'suite',
+  'suiteSetup',
+  'suiteTeardown',
+  'teardown',
+  'test',
+  'xcontext',
+  'xdescribe',
+  'xit',
+  'xspecify',
+]);


### PR DESCRIPTION
This PR adds a new transform to handle the renaming of some things that are injected into the test context (`spy`/ `stub`/ `clock` etc) to use a global defined for the tests instead. The codemod allows you to define these as either replacing the whole member expression (`this.clock -> testClock`) or to just replace the object in the member expression with the test global (`this.spy -> sinon.spy`).

cc/ @goodforonefare