### PR TITLE
Don't try to transform non-Mocha functions

### DIFF
--- a/packages/shopify-codemod/test/fixtures/mocha-context-to-closure/contextually-declared-functions.input.js
+++ b/packages/shopify-codemod/test/fixtures/mocha-context-to-closure/contextually-declared-functions.input.js
@@ -9,4 +9,7 @@ suite('top-level', function() {
       return this.foo === 'mystery';
     }
   });
+
+  // Suites may call methods that generate tests.
+  shouldNotBeTransformed();
 });

--- a/packages/shopify-codemod/test/fixtures/mocha-context-to-closure/contextually-declared-functions.output.js
+++ b/packages/shopify-codemod/test/fixtures/mocha-context-to-closure/contextually-declared-functions.output.js
@@ -11,4 +11,7 @@ suite('top-level', function() {
       return this.foo === 'mystery';
     }
   });
+
+  // Suites may call methods that generate tests.
+  shouldNotBeTransformed();
 });

--- a/packages/shopify-codemod/transforms/mocha-context-to-closure.js
+++ b/packages/shopify-codemod/transforms/mocha-context-to-closure.js
@@ -1,3 +1,5 @@
+import {MOCHA_FUNCTIONS} from './utils';
+
 export default function mochaContextToClosure({source}, {jscodeshift: j}, {printOptions = {quote: 'single'}}) {
   let currentContext;
   const root = j(source);
@@ -112,6 +114,7 @@ export default function mochaContextToClosure({source}, {jscodeshift: j}, {print
 
     root
       .find(j.CallExpression)
+      .filter(({node}) => MOCHA_FUNCTIONS.has(node.callee.name))
       .filter(isScopedToContext)
       .replaceWith((callPath) => {
         if (setsContextProperties(callPath)) { return handleContextSetter(callPath); }


### PR DESCRIPTION
Previously, `handleContext` would try to transform *any* function inside a suite.  This broke when suites invoked non-Mocha functions (e.g., `itDoesNotRemoveTheErrorClass` in `error_remover_test.coffee`).

/cc @lemonmade 