### PR TITLE
Fix function to arrow

### DIFF
--- a/packages/shopify-codemod/test/fixtures/function-to-arrow/method.input.js
+++ b/packages/shopify-codemod/test/fixtures/function-to-arrow/method.input.js
@@ -1,0 +1,5 @@
+class Foo {
+  shouldNotConvertToArrow() {
+    return;
+  }
+}

--- a/packages/shopify-codemod/test/fixtures/function-to-arrow/method.output.js
+++ b/packages/shopify-codemod/test/fixtures/function-to-arrow/method.output.js
@@ -1,0 +1,5 @@
+class Foo {
+  shouldNotConvertToArrow() {
+    return;
+  }
+}

--- a/packages/shopify-codemod/test/fixtures/function-to-arrow/return-without-argument.input.js
+++ b/packages/shopify-codemod/test/fixtures/function-to-arrow/return-without-argument.input.js
@@ -1,0 +1,3 @@
+var shouldBecomeEmptyArrowFunction = function() {
+  return;
+};

--- a/packages/shopify-codemod/test/fixtures/function-to-arrow/return-without-argument.output.js
+++ b/packages/shopify-codemod/test/fixtures/function-to-arrow/return-without-argument.output.js
@@ -1,0 +1,1 @@
+var shouldBecomeEmptyArrowFunction = () => {};

--- a/packages/shopify-codemod/test/transforms/function-to-arrow.test.js
+++ b/packages/shopify-codemod/test/transforms/function-to-arrow.test.js
@@ -17,4 +17,8 @@ describe('functionToArrow', () => {
   it("doesn't transform methods", () => {
     expect(functionToArrow).to.transform('function-to-arrow/method');
   });
+
+  it('transforms return without argument to empty arrow function', () => {
+    expect(functionToArrow).to.transform('function-to-arrow/return-without-argument');
+  });
 });

--- a/packages/shopify-codemod/test/transforms/function-to-arrow.test.js
+++ b/packages/shopify-codemod/test/transforms/function-to-arrow.test.js
@@ -13,4 +13,8 @@ describe('functionToArrow', () => {
   it("doesn't break on property method shorthand", () => {
     expect(functionToArrow).to.transform('function-to-arrow/property');
   });
+
+  it("doesn't transform methods", () => {
+    expect(functionToArrow).to.transform('function-to-arrow/method');
+  });
 });

--- a/packages/shopify-codemod/test/transforms/function-to-arrow.test.js
+++ b/packages/shopify-codemod/test/transforms/function-to-arrow.test.js
@@ -1,16 +1,16 @@
 import 'test-helper';
-import ternaryStatementToIfStatement from 'function-to-arrow';
+import functionToArrow from 'function-to-arrow';
 
 describe('functionToArrow', () => {
   it('transforms the simple case', () => {
-    expect(ternaryStatementToIfStatement).to.transform('function-to-arrow/basic');
+    expect(functionToArrow).to.transform('function-to-arrow/basic');
   });
 
   it("doesn't transform function that use `this`", () => {
-    expect(ternaryStatementToIfStatement).to.transform('function-to-arrow/this');
+    expect(functionToArrow).to.transform('function-to-arrow/this');
   });
 
   it("doesn't break on property method shorthand", () => {
-    expect(ternaryStatementToIfStatement).to.transform('function-to-arrow/property');
+    expect(functionToArrow).to.transform('function-to-arrow/property');
   });
 });

--- a/packages/shopify-codemod/transforms/function-to-arrow.js
+++ b/packages/shopify-codemod/transforms/function-to-arrow.js
@@ -1,7 +1,8 @@
 export default function functionToArrow({source}, {jscodeshift: j}, {printOptions = {}}) {
   return j(source)
     .find(j.FunctionExpression)
-    .filter((path) => j(path).find(j.ThisExpression).size() === 0 && !j.Property.check(path.parent.node))
+    .filter(({parent}) => !j.MethodDefinition.check(parent.node) && !j.Property.check(parent.node))
+    .filter((path) => j(path).find(j.ThisExpression).size() === 0)
     .replaceWith(({node}) => {
       const {params} = node;
       let {body} = node;

--- a/packages/shopify-codemod/transforms/function-to-arrow.js
+++ b/packages/shopify-codemod/transforms/function-to-arrow.js
@@ -1,8 +1,19 @@
 export default function functionToArrow({source}, {jscodeshift: j}, {printOptions = {}}) {
+  function isMember({parent}) {
+    return j.MethodDefinition.check(parent.node) || j.Property.check(parent.node);
+  }
+
+  function containsThisExpression(path) {
+    return j(path).find(j.ThisExpression).size() > 0;
+  }
+
+  function isConvertibleFunction(path) {
+    return !isMember(path) && !containsThisExpression(path);
+  }
+
   return j(source)
     .find(j.FunctionExpression)
-    .filter(({parent}) => !j.MethodDefinition.check(parent.node) && !j.Property.check(parent.node))
-    .filter((path) => j(path).find(j.ThisExpression).size() === 0)
+    .filter(isConvertibleFunction)
     .replaceWith(({node}) => {
       const {params} = node;
       let {body} = node;

--- a/packages/shopify-codemod/transforms/function-to-arrow.js
+++ b/packages/shopify-codemod/transforms/function-to-arrow.js
@@ -9,7 +9,11 @@ export default function functionToArrow({source}, {jscodeshift: j}, {printOption
       const originalBody = body.body;
       // If there is just a single ReturnStatement, just replace the whole body.
       if (originalBody.length === 1 && originalBody[0].type === 'ReturnStatement') {
-        body = originalBody[0].argument;
+        if (originalBody[0].argument != null) {
+          body = originalBody[0].argument;
+        } else {
+          body = j.blockStatement([]);
+        }
       }
       return j.arrowFunctionExpression(params, body, body.type !== 'BlockStatement');
     })


### PR DESCRIPTION
Fixes `function-to-arrow` by:
- Ignoring class methods
  - (I know that `transform-class-properties` is enabled, but, eh, stage 1)
- Handling functions with argument-less `return`s

/cc @lemonmade 