### PR TITLE
Strip argless returns if they're the last line of a Mocha function

### DIFF
--- a/packages/shopify-codemod/test/fixtures/remove-useless-return-from-test/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/remove-useless-return-from-test/basic.input.js
@@ -1,4 +1,7 @@
 suite('a', () => {
+  beforeEach(function() {
+    return;
+  });
   beforeEach(() => {
     return a();
   });

--- a/packages/shopify-codemod/test/fixtures/remove-useless-return-from-test/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/remove-useless-return-from-test/basic.output.js
@@ -1,4 +1,5 @@
 suite('a', () => {
+  beforeEach(function() {});
   beforeEach(() => {
     a();
   });

--- a/packages/shopify-codemod/transforms/remove-useless-return-from-test.js
+++ b/packages/shopify-codemod/transforms/remove-useless-return-from-test.js
@@ -23,7 +23,12 @@ export default function removeUselessReturnFromTest({source}, {jscodeshift: j}, 
     })
     .forEach((path) => {
       const {body: {body}} = path.node.arguments[path.node.arguments.length - 1];
-      body[body.length - 1] = j.expressionStatement(body[body.length - 1].argument);
+      const returnStatement = body[body.length - 1];
+      if (returnStatement.argument) {
+        body[body.length - 1] = j.expressionStatement(returnStatement.argument);
+      } else {
+        body.pop();
+      }
     })
     .toSource(printOptions);
 }


### PR DESCRIPTION
Gets rid of `return;` lines from Mocha functions (these were breaking tests like `amount_validation_test.coffee`).

/cc @lemonmade 