### PR TITLE
Add some ESLint rules

### DIFF
--- a/packages/eslint-plugin-shopify/README.md
+++ b/packages/eslint-plugin-shopify/README.md
@@ -76,7 +76,7 @@ This plugin provides the following custom rules, which are included as appropria
 
 ## Creating New Rules
 
-The easiest way to add new rules is to use the [ESLint Yeoman generator](https://www.npmjs.com/package/generator-eslint). Running `yo eslint:rule` from the root of this project should add the required main file, docs, and test for your new rules. Make sure that these are all filled out and consistent with the other rules before merging. All tests (including linting) can be run using `npm test`.
+The easiest way to add new rules is to use the [ESLint Yeoman generator](https://www.npmjs.com/package/generator-eslint). Running `yo eslint:rule` from the root of this project should add the required main file, docs, and test for your new rules. Make sure that these are all filled out and consistent with the other rules before merging. All tests can be run using `npm test`.
 
 [npm-url]: https://npmjs.org/package/eslint-plugin-shopify
 [npm-image]: http://img.shields.io/npm/v/eslint-plugin-shopify.svg?style=flat-square

--- a/packages/eslint-plugin-shopify/README.md
+++ b/packages/eslint-plugin-shopify/README.md
@@ -75,6 +75,11 @@ This plugin provides the following custom rules, which are included as appropria
 - [binary-assignment-parens](docs/rules/binary-assignment-parens.md): Requires (or disallows) assignments of binary, boolean-producing expressions to be wrapped in parentheses.
 - [prefer-early-return](docs/rules/prefer-early-return.md): Prefer early returns over full-body conditional wrapping in function declarations.
 - [jquery-dollar-sign-reference](docs/rules/jquery-dollar-sign-reference.md): Requires that all jQuery objects are assigned to references prefixed with `$`.
+- [class-property-semi](docs/rules/class-property-semi.md): Requires (or disallows) semicolons for class properties.
+- [no-useless-computed-properties](docs/rules/no-useless-computed-properties.md): Prevents the usage of unnecessary computed properties.
+- [restrict-full-import](docs/rules/restrict-full-import.md): Prevents importing the entirety of a package.
+- [sinon-no-restricted-features](docs/rules/sinon-no-restricted-features.md): Restricts the use of specified sinon features.
+- [sinon-prefer-meaningful-assertions](docs/rules/sinon-prefer-meaningful-assertions.md): Requires the use of meaningful sinon assertions through sinon.assert or sinon-chai.
 
 ## Creating New Rules
 

--- a/packages/eslint-plugin-shopify/README.md
+++ b/packages/eslint-plugin-shopify/README.md
@@ -71,12 +71,12 @@ This plugin also provides the following tool-specific configurations, which can 
 
 This plugin provides the following custom rules, which are included as appropriate in all core linting configs:
 
-- [require-flow](docs/rules/require-flow.md): Requires (or disallows) @flow declarations be present at the top of each file.
 - [binary-assignment-parens](docs/rules/binary-assignment-parens.md): Requires (or disallows) assignments of binary, boolean-producing expressions to be wrapped in parentheses.
-- [prefer-early-return](docs/rules/prefer-early-return.md): Prefer early returns over full-body conditional wrapping in function declarations.
-- [jquery-dollar-sign-reference](docs/rules/jquery-dollar-sign-reference.md): Requires that all jQuery objects are assigned to references prefixed with `$`.
 - [class-property-semi](docs/rules/class-property-semi.md): Requires (or disallows) semicolons for class properties.
+- [jquery-dollar-sign-reference](docs/rules/jquery-dollar-sign-reference.md): Requires that all jQuery objects are assigned to references prefixed with `$`.
 - [no-useless-computed-properties](docs/rules/no-useless-computed-properties.md): Prevents the usage of unnecessary computed properties.
+- [prefer-early-return](docs/rules/prefer-early-return.md): Prefer early returns over full-body conditional wrapping in function declarations.
+- [require-flow](docs/rules/require-flow.md): Requires (or disallows) @flow declarations be present at the top of each file.
 - [restrict-full-import](docs/rules/restrict-full-import.md): Prevents importing the entirety of a package.
 - [sinon-no-restricted-features](docs/rules/sinon-no-restricted-features.md): Restricts the use of specified sinon features.
 - [sinon-prefer-meaningful-assertions](docs/rules/sinon-prefer-meaningful-assertions.md): Requires the use of meaningful sinon assertions through sinon.assert or sinon-chai.

--- a/packages/eslint-plugin-shopify/README.md
+++ b/packages/eslint-plugin-shopify/README.md
@@ -73,6 +73,8 @@ This plugin provides the following custom rules, which are included as appropria
 
 - [require-flow](docs/rules/require-flow.md): Requires (or disallows) @flow declarations be present at the top of each file.
 - [binary-assignment-parens](docs/rules/binary-assignment-parens.md): Requires (or disallows) assignments of binary, boolean-producing expressions to be wrapped in parentheses.
+- [prefer-early-return](docs/rules/prefer-early-return.md): Prefer early returns over full-body conditional wrapping in function declarations.
+- [jquery-dollar-sign-reference](docs/rules/jquery-dollar-sign-reference.md): Requires that all jQuery objects are assigned to references prefixed with `$`.
 
 ## Creating New Rules
 

--- a/packages/eslint-plugin-shopify/docs/rules/class-property-semi.md
+++ b/packages/eslint-plugin-shopify/docs/rules/class-property-semi.md
@@ -1,0 +1,29 @@
+# Requires (or disallows) semicolons for class properties. (class-property-semi)
+
+## Rule Details
+
+This rule takes one argument. If it is `'always'` (default) then it warns when it does not find a semicolon at the end of a class property. If `'never'` then it warns if a semicolon is present.
+
+The following patterns are considered warnings when using the default or explicitly setting the argument to `'always'`:
+
+```js
+class Foo {
+  bar = true
+  static baz = false
+}
+```
+
+The following patterns are not warnings when using the default or explicitly setting the argument to `'always'`:
+
+```js
+class Foo {
+  bar = true;
+  static baz = false;
+}
+```
+
+The success/ failure cases are reversed when the argument is explicitly `'never'`.
+
+## When Not To Use It
+
+If you do not wish to enforce semicolons for class properties, then you can safely disable this rule.

--- a/packages/eslint-plugin-shopify/docs/rules/jquery-dollar-sign-reference.md
+++ b/packages/eslint-plugin-shopify/docs/rules/jquery-dollar-sign-reference.md
@@ -1,0 +1,53 @@
+# Requires that all jQuery objects are assigned to references prefixed with `$`. (jquery-dollar-sign-reference)
+
+Identifying a reference as being a jQuery object makes it immediately obvious what methods are available on that reference.
+
+## Rule Details
+
+This rule aims to ensure that all jQuery references are prefixed with a `$`, and that all references prefixed with a `$` refer only to jQuery objects.
+
+The following patterns are considered warnings:
+
+```js
+var foo = $('.bar');
+var foo = jQuery('.bar');
+
+var obj = {
+  foo: $('.bar');
+};
+
+var obj = {};
+obj['foo'] = $('.bar');
+
+var foo = $('.bar').addClass('someClass').attr({bar: 'baz'});
+
+var $foo = $.Deferred();
+var $foo = 'something else';
+var $foo = $('.bar').html(); // actually returns a string
+var $foo = $('.bar').attr('someAttr'); // does not return a jQuery object
+```
+
+The following patterns are not warnings:
+
+```js
+var $foo = $('.bar');
+
+var obj = {
+  $foo: $('.bar');
+};
+
+var obj = {};
+obj['$foo'] = $('.bar');
+
+var $foo = $('.bar').addClass('someClass').attr({bar: 'baz'});
+var $foo = something();
+
+var foo = $.Deferred();
+var foo = 'something else';
+var foo = $('.bar').html();
+var foo = $('.bar').attr('someAttr');
+```
+
+## When Not To Use It
+
+If you don't use jQuery or you don't care how jQuery references are named, you can safely disable this rule.

--- a/packages/eslint-plugin-shopify/docs/rules/no-useless-computed-properties.md
+++ b/packages/eslint-plugin-shopify/docs/rules/no-useless-computed-properties.md
@@ -1,0 +1,39 @@
+# Prevents the usage of unnecessary computed properties. (no-useless-computed-properties)
+
+Computed properties allow you to define methods and properties of an object or class without having to know exact name of the key.
+
+## Rule Details
+
+This rule aims to prevent the use of a computed property when the value being computed is a literal (and could therefore omit the computed property altogether).
+
+The following patterns are considered warnings:
+
+```js
+var foo = {
+  ['bar']: true,
+}
+
+class Foo {
+  ['bar']() {}
+  static [123]() {}
+}
+```
+
+The following patterns are not warnings:
+
+```js
+var foo = {
+  'bar': true,
+  baz: true,
+  [qux]: true,
+  [buzz()]: true,
+}
+```
+
+## When Not To Use It
+
+If you do not care about unnecessarily computed properties, you can safely disable this rule.
+
+## Further Reading
+
+- [Object initializers on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer);

--- a/packages/eslint-plugin-shopify/docs/rules/prefer-early-return.md
+++ b/packages/eslint-plugin-shopify/docs/rules/prefer-early-return.md
@@ -1,0 +1,72 @@
+# Prefer early returns over full-body conditional wrapping in function declarations. (prefer-early-return)
+
+A function whose entire body is nested under a conditional statement adds unnecessary nesting and makes the code harder to read. An early return often makes the block more readable.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+function foo() {
+  if (a) {
+    b();
+    c();
+  }
+}
+```
+
+The following patterns are not warnings:
+
+```js
+function foo() {
+  if (!a) { return; }
+
+  b();
+  c();
+}
+
+function bar() {
+  if (a) {
+    b();
+    c();
+  }
+
+  d();
+}
+
+function baz() {
+  if (a) {
+    b();
+    c();
+  } else {
+    d();
+  }
+}
+```
+
+### Options
+
+This plugin takes one option: an object with a integer `maximumStatements` property. This property specifies the maximum number of statements in the conditional for which a full-function body conditional should be allowed. By default, this value is `1`, so the following will **not** be considered a warning:
+
+```js
+function foo() {
+  if (a) {
+    b();
+  }
+}
+```
+
+Setting `maximumStatements` to `0` will cause the above to be a warning. Setting `maximumStatements` to `2` would cause the following **not** to be considered a warning:
+
+```js
+function foo() {
+  if (a) {
+    b();
+    c();
+  }
+}
+```
+
+## When Not To Use It
+
+If you don't care about conditionals that span the entire body of functions, or dislike early returns, you can safely disable this rule.

--- a/packages/eslint-plugin-shopify/docs/rules/require-flow.md
+++ b/packages/eslint-plugin-shopify/docs/rules/require-flow.md
@@ -1,30 +1,30 @@
 # Requires (or disallows) @flow declarations be present at the top of each file. (require-flow)
 
-[Flow](http://flowtype.org/) is a static type checker designed by Facebook. It is highly recommended that you use this on all JavaScript project.
+[Flow](http://flowtype.org/) is a static type checker designed by Facebook.
 
 ## Rule Details
 
-This rule takes one argument. If it is `"always"` (default) then it warns when it does not find a flow declaration (`/* @flow */`) at the top of a file. If `"explicit"` it accepts either `@flow` or `@noflow`. If `"never"` then it warns if a flow declaration is present.
+This rule takes one argument. If it is `'always'` (default) then it warns when it does not find a flow declaration (`/* @flow */`) at the top of a file. If `'explicit'` it accepts either `@flow` or `@noflow`. If `'never'` then it warns if a flow declaration is present.
 
-The following patterns are considered warnings when using the default or explicitly setting the argument to `"always"` or `"explicit"`:
+The following patterns are considered warnings when using the default or explicitly setting the argument to `'always'` or `'explicit'`:
 
-```javascript
+```js
 function noFlow(...args) { return 'sorry!'; }
 ```
 
-The following patterns are not warnings when using the default or explicitly setting the argument to `"always"`:
+The following patterns are not warnings when using the default or explicitly setting the argument to `'always'`:
 
-```javascript
+```js
 /* @flow */
 
 function iHaveTheFlow(...args: Array<any>): string { return 'awesome!'; }
 ```
 
-The success/ failure cases are reversed when the argument is explicitly `"never"`.
+The success/ failure cases are reversed when the argument is explicitly `'never'`.
 
-Additionally, the following patterns are not warnings when explicitly setting the argument to `"explicit"`:
+Additionally, the following patterns are not warnings when explicitly setting the argument to `'explicit'`:
 
-```javascript
+```js
 /* @noflow */
 
 function iHaveTheFlow(...args: Array<any>): string { return 'awesome!'; }

--- a/packages/eslint-plugin-shopify/docs/rules/restrict-full-import.md
+++ b/packages/eslint-plugin-shopify/docs/rules/restrict-full-import.md
@@ -1,0 +1,38 @@
+# Prevents importing the entirety of a package. (restrict-full-import)
+
+Importing the entirety of a large module can be undesirable because it becomes harder to track what properties are being used.
+
+## Rule Details
+
+This rule prevents default imports for a configurable list of modules. This is **not** a module blacklist; individual properties can still be imported, including those from the list of modules provided to this rule.
+
+This rule takes a single argument, an array of module names that should not be fully imported.
+
+The following patterns are considered warnings with the option `['lodash']`:
+
+```js
+import _ from 'lodash';
+import _, {chain} from 'lodash';
+import {default as _} from 'lodash';
+import * as _ from 'lodash';
+
+var _ = require('lodash');
+var {chain, ...rest} = require('lodash');
+```
+
+The following patterns are not warnings:
+
+```js
+import _ from 'something-else';
+import {chain, map} from 'lodash';
+import chain from 'lodash/chain';
+
+var _ = require('something-else');
+var chain = require('lodash').chain;
+var chain = require('lodash/chain');
+var {chain} = require('lodash');
+```
+
+## When Not To Use It
+
+If you do not want to restrict default imports from any modules, you can safely disable this rule.

--- a/packages/eslint-plugin-shopify/docs/rules/sinon-no-restricted-features.md
+++ b/packages/eslint-plugin-shopify/docs/rules/sinon-no-restricted-features.md
@@ -1,0 +1,63 @@
+# Restricts the use of specified sinon features. (sinon-no-restricted-features)
+
+[`sinon`](http://sinonjs.org) offers many of features, some of which you may not want to use in your codebase.
+
+## Rule Details
+
+By default, no properties are restricted.
+
+### Options
+
+This rule takes a single object option. That option allows you to specify any set of the following options:
+
+### `restricted`
+
+This option should be an array that specifies the properties of `sinon` that are restricted. With `{restricted: ['mock', 'clock']}`, the following patterns are considered warnings:
+
+```js
+sinon.mock(myObject).expects('myMethod');
+sinon.clock.tick(300);
+```
+
+The following patterns are not warnings:
+
+```js
+sinon.stub(myObject, 'myMethod');
+somethingElse.mock();
+```
+
+### `aliases`
+
+This option should be an array that specifies other identifiers that are used in place in `sinon` in your codebase. This can be useful if you create a separate global for a sinon sandbox. You must explicitly add `sinon` to this array for it to continue to be flagged. With `{aliases: ['sandbox'], restricted: ['mock']}`, the following patterns are considered warnings:
+
+```js
+sandbox.mock(myObject).expects('myMethod');
+```
+
+The following patterns are not warnings:
+
+```js
+sinon.mock(myObject).expects('myMethod');
+somethingElse.mock();
+```
+
+### `injected`
+
+This option should be a boolean that specifies whether `sinon` is injected into the context (that is, its properties are available on `this`). With `{injected: true, restricted: ['mock']}`, the following patterns are considered warnings:
+
+```js
+sinon.mock(myObject).expects('myMethod');
+this.mock(myObject).expects('myMethod');
+```
+
+The following patterns are not warnings:
+
+```js
+sandbox.mock(myObject).expects('myMethod');
+this.stub(myObject, 'myMethod');
+somethingElse.mock();
+```
+
+## When Not To Use It
+
+If you don’t want to restrict any `sinon` properties, you can safely disable this rule.

--- a/packages/eslint-plugin-shopify/docs/rules/sinon-prefer-meaningful-assertions.md
+++ b/packages/eslint-plugin-shopify/docs/rules/sinon-prefer-meaningful-assertions.md
@@ -1,0 +1,53 @@
+# Requires the use of meaningful sinon assertions through sinon.assert or sinon-chai. (sinon-prefer-meaningful-assertions)
+
+Sinon provides [spy-specific assertions](http://sinonjs.org/docs/#assertions) that have more useful error messages. These same, more meaningful assertions are also available for BDD-style tests using [sinon-chai](https://github.com/domenic/sinon-chai).
+
+## Rule Details
+
+This rule aims to enforce that you always use the more meaningful sinon assertions where possible.
+
+The following patterns are considered warnings:
+
+```js
+// assert
+assert.true(mySpy.called);
+assert.equal(mySpy.callCount, 3);
+assert.true(mySpy.alwaysCalledWith(foo));
+
+// expect
+expect(mySpy.called).to.be.true;
+expect(mySpy.callCount).to.equal(3);
+expect(mySpy.myMethod.alwaysCalledWith(foo)).to.be.true;
+expect(mySpy.myMethod.alwaysCalledWithNew).to.be.true;
+
+// should
+mySpy.called.should.be.true;
+mySpy.callCount.should.equal(3);
+mySpy.myMethod.alwaysCalledWith(foo).should.be.true;
+mySpy.myMethod.alwaysCalledWithNew.should.be.true;
+```
+
+The following patterns are not warnings:
+
+```js
+// assert
+assert.called(mySpy);
+assert.callCount(mySpy, 3);
+assert.alwaysCalledWith(mySpy, foo);
+assert.true(mySpy.calledWithNew()); // no dedicated assert method
+assert.true(called); // smart enough to detect when it's probably a spy
+
+expect(mySpy).to.have.been.called;
+expect(mySpy).to.have.callCount(3);
+expect(mySpy.myMethod).to.have.been.alwaysCalledWith(foo);
+expect(mySpy.myMethod).to.have.been.alwaysCalledWithNew;
+
+mySpy.to.have.been.called;
+mySpy.to.have.callCount(3);
+mySpy.myMethod.should.have.been.alwaysCalledWith(foo);
+mySpy.myMethod.should.have.been.alwaysCalledWithNew;
+```
+
+## When Not To Use It
+
+If you don’t use sinon, or don’t care about having more meaningful assertion messages, you can safely disable this rule.

--- a/packages/eslint-plugin-shopify/index.js
+++ b/packages/eslint-plugin-shopify/index.js
@@ -2,6 +2,8 @@ module.exports = {
   rules: {
     'require-flow': require('./lib/rules/require-flow'),
     'binary-assignment-parens': require('./lib/rules/binary-assignment-parens'),
+    'prefer-early-return': require('./lib/rules/prefer-early-return'),
+    'jquery-dollar-sign-reference': require('./lib/rules/jquery-dollar-sign-reference'),
   },
 
   configs: {

--- a/packages/eslint-plugin-shopify/index.js
+++ b/packages/eslint-plugin-shopify/index.js
@@ -1,9 +1,14 @@
 module.exports = {
   rules: {
-    'require-flow': require('./lib/rules/require-flow'),
     'binary-assignment-parens': require('./lib/rules/binary-assignment-parens'),
-    'prefer-early-return': require('./lib/rules/prefer-early-return'),
+    'class-property-semi': require('./lib/rules/class-property-semi'),
     'jquery-dollar-sign-reference': require('./lib/rules/jquery-dollar-sign-reference'),
+    'no-useless-computed-properties': require('./lib/rules/no-useless-computed-properties'),
+    'prefer-early-return': require('./lib/rules/prefer-early-return'),
+    'require-flow': require('./lib/rules/require-flow'),
+    'restrict-full-import': require('./lib/rules/restrict-full-import'),
+    'sinon-no-restricted-features': require('./lib/rules/sinon-no-restricted-features'),
+    'sinon-prefer-meaningful-assertions': require('./lib/rules/sinon-prefer-meaningful-assertions'),
   },
 
   configs: {

--- a/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
@@ -1,16 +1,16 @@
 module.exports = {
-  // Requires (or disallows) @flow declarations be present at the top of each file.
-  'shopify/require-flow': 'off',
   // Requires (or disallows) assignments of binary, boolean-producing expressions to be wrapped in parentheses.
   'shopify/binary-assignment-parens': ['warn', 'always'],
-  // Prefer early returns over full-body conditional wrapping in function declarations.
-  'shopify/prefer-early-return': ['warn', {maximumStatements: 1}],
-  // Requires that all jQuery objects are assigned to references prefixed with `$`.
-  'shopify/jquery-dollar-sign-reference': 'warn',
   // Requires (or disallows) semicolons for class properties.
   'shopify/class-property-semi': 'warn',
+  // Requires that all jQuery objects are assigned to references prefixed with `$`.
+  'shopify/jquery-dollar-sign-reference': 'warn',
   // Prevents the usage of unnecessary computed properties.
   'shopify/no-useless-computed-properties': 'error',
+  // Prefer early returns over full-body conditional wrapping in function declarations.
+  'shopify/prefer-early-return': ['warn', {maximumStatements: 1}],
+  // Requires (or disallows) @flow declarations be present at the top of each file.
+  'shopify/require-flow': 'off',
   // Prevents importing the entirety of a package.
   'shopify/restrict-full-import': 'off',
   // Restricts the use of specified sinon features.

--- a/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
@@ -3,4 +3,6 @@ module.exports = {
   'shopify/require-flow': 'off',
   // Requires (or disallows) assignments of binary, boolean-producing expressions to be wrapped in parentheses.
   'shopify/binary-assignment-parens': ['warn', 'always'],
+  // Prefer early returns over full-body conditional wrapping in function declarations.
+  'shopify/prefer-early-return': ['warn', {maximumStatements: 1}],
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
@@ -7,4 +7,14 @@ module.exports = {
   'shopify/prefer-early-return': ['warn', {maximumStatements: 1}],
   // Requires that all jQuery objects are assigned to references prefixed with `$`.
   'shopify/jquery-dollar-sign-reference': 'warn',
+  // Requires (or disallows) semicolons for class properties.
+  'shopify/class-property-semi': 'warn',
+  // Prevents the usage of unnecessary computed properties.
+  'shopify/no-useless-computed-properties': 'error',
+  // Prevents importing the entirety of a package.
+  'shopify/restrict-full-import': 'off',
+  // Restricts the use of specified sinon features.
+  'shopify/sinon-no-restricted-features': 'off',
+  // Requires the use of meaningful sinon assertions through sinon.assert or sinon-chai.
+  'shopify/sinon-prefer-meaningful-assertions': 'off',
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
@@ -5,4 +5,6 @@ module.exports = {
   'shopify/binary-assignment-parens': ['warn', 'always'],
   // Prefer early returns over full-body conditional wrapping in function declarations.
   'shopify/prefer-early-return': ['warn', {maximumStatements: 1}],
+  // Requires that all jQuery objects are assigned to references prefixed with `$`.
+  'shopify/jquery-dollar-sign-reference': 'warn',
 };

--- a/packages/eslint-plugin-shopify/lib/rules/class-property-semi.js
+++ b/packages/eslint-plugin-shopify/lib/rules/class-property-semi.js
@@ -1,0 +1,41 @@
+module.exports = function(context) {
+
+  var config = context.options[0] || 'always';
+  var always = (config === 'always');
+
+  function isSemicolon(token) {
+    return token.type === 'Punctuator' && token.value === ';';
+  }
+
+  function checkClassProperty(node) {
+    var lastToken = context.getLastToken(node);
+    var hasSemicolon = isSemicolon(lastToken);
+
+    if (always && !hasSemicolon) {
+      context.report({
+        node: node,
+        message: 'Missing semicolon.',
+        fix: function(fixer) {
+          fixer.insertTextAfter(lastToken, ';');
+        },
+      });
+    } else if (!always && hasSemicolon) {
+      context.report({
+        node: node,
+        message: 'Extra semicolon.',
+        fix: function(fixer) {
+          fixer.remove(lastToken);
+        },
+      });
+    }
+  }
+
+  return {
+    ClassProperty: checkClassProperty,
+  };
+
+};
+
+module.exports.schema = [{
+  enum: ['always', 'never'],
+}];

--- a/packages/eslint-plugin-shopify/lib/rules/jquery-dollar-sign-reference.js
+++ b/packages/eslint-plugin-shopify/lib/rules/jquery-dollar-sign-reference.js
@@ -25,16 +25,16 @@ var nonChainingMethods = {
   val: true,
   width: true,
 
-  html: function(node) {
-    return node.arguments.length === 0;
+  attr: function(node) {
+    return node.arguments.length < 2 && node.arguments[0] && node.arguments[0].type !== 'ObjectExpression';
   },
   data: function(node) {
     return node.arguments.length < 2 && node.arguments[0] && node.arguments[0].type !== 'ObjectExpression';
   },
-  prop: function(node) {
-    return node.arguments.length < 2 && node.arguments[0] && node.arguments[0].type !== 'ObjectExpression';
+  html: function(node) {
+    return node.arguments.length === 0;
   },
-  attr: function(node) {
+  prop: function(node) {
     return node.arguments.length < 2 && node.arguments[0] && node.arguments[0].type !== 'ObjectExpression';
   },
 };
@@ -52,8 +52,7 @@ module.exports = function(context) {
   }
 
   function isjQueryReference(node) {
-    var referenceName = getFinalReferenceName(node);
-    return referenceName != null && JQUERY_IDENTIFIER_REGEX.test(referenceName);
+    return JQUERY_IDENTIFIER_REGEX.test(getFinalReferenceName(node));
   }
 
   function isjQueryCallExpression(node) {
@@ -103,11 +102,11 @@ module.exports = function(context) {
     }
   }
 
-  function handleVariableDeclarator(node) {
+  function checkVariableDeclarator(node) {
     checkForValidjQueryReference(node, node.id, node.init);
   }
 
-  function handleAssignmentExpression(node) {
+  function checkAssignmentExpression(node) {
     if (node.left.type === 'MemberExpression' && node.left.computed && node.left.property.type !== 'Literal') {
       return;
     }
@@ -115,7 +114,7 @@ module.exports = function(context) {
     checkForValidjQueryReference(node, node.left, node.right);
   }
 
-  function handleObjectExpression(node) {
+  function checkObjectExpression(node) {
     node.properties.forEach(function(prop) {
       if (prop.computed && prop.key.type !== 'Literal') {
         return;
@@ -125,7 +124,7 @@ module.exports = function(context) {
     });
   }
 
-  function handleClassProperty(node) {
+  function checkClassProperty(node) {
     var tokens = context.getFirstTokens(node, 2).filter(function(token) {
       return token.type === 'Identifier';
     });
@@ -139,14 +138,9 @@ module.exports = function(context) {
   }
 
   return {
-    VariableDeclarator: handleVariableDeclarator,
-    AssignmentExpression: handleAssignmentExpression,
-    ObjectExpression: handleObjectExpression,
-    ClassProperty: handleClassProperty,
-    // Program: function(node) { console.log(node); }
+    VariableDeclarator: checkVariableDeclarator,
+    AssignmentExpression: checkAssignmentExpression,
+    ObjectExpression: checkObjectExpression,
+    ClassProperty: checkClassProperty,
   };
 };
-
-module.exports.schema = [
-    // fill in your schema
-];

--- a/packages/eslint-plugin-shopify/lib/rules/jquery-dollar-sign-reference.js
+++ b/packages/eslint-plugin-shopify/lib/rules/jquery-dollar-sign-reference.js
@@ -1,0 +1,152 @@
+var JQUERY_IDENTIFIERS = ['$', 'jQuery'];
+
+var nonChainingMethods = {
+  context: true,
+  get: true,
+  hasClass: true,
+  height: true,
+  index: true,
+  innerHeight: true,
+  innerWidth: true,
+  is: true,
+  offset: true,
+  outerHeight: true,
+  outerWidth: true,
+  position: true,
+  promise: true,
+  scrollLeft: true,
+  scrollTop: true,
+  serialize: true,
+  serializeArray: true,
+  size: true,
+  text: true,
+  toArray: true,
+  triggerHandler: true,
+  val: true,
+  width: true,
+
+  html: function(node) {
+    return node.arguments.length === 0;
+  },
+  data: function(node) {
+    return node.arguments.length < 2 && node.arguments[0] && node.arguments[0].type !== 'ObjectExpression';
+  },
+  prop: function(node) {
+    return node.arguments.length < 2 && node.arguments[0] && node.arguments[0].type !== 'ObjectExpression';
+  },
+  attr: function(node) {
+    return node.arguments.length < 2 && node.arguments[0] && node.arguments[0].type !== 'ObjectExpression';
+  },
+};
+
+var JQUERY_IDENTIFIER_REGEX = /^\$./;
+
+module.exports = function(context) {
+  function getFinalReferenceName(node) {
+    switch (node.type) {
+    case 'Identifier': return node.name;
+    case 'Literal': return node.value;
+    case 'MemberExpression': return getFinalReferenceName(node.property);
+    default: return null;
+    }
+  }
+
+  function isjQueryReference(node) {
+    var referenceName = getFinalReferenceName(node);
+    return referenceName != null && JQUERY_IDENTIFIER_REGEX.test(referenceName);
+  }
+
+  function isjQueryCallExpression(node) {
+    return isCallExpression(node) && JQUERY_IDENTIFIERS.indexOf(node.callee.name) >= 0;
+  }
+
+  function isCallExpression(node) {
+    return node.type === 'CallExpression';
+  }
+
+  function isjQueryStartValue(node) {
+    return (node.type === 'Identifier' && isjQueryReference(node)) || isjQueryCallExpression(node);
+  }
+
+  function isjQueryValue(node) {
+    var relevantNode = node;
+    var validChain = true;
+
+    while (relevantNode.callee && relevantNode.callee.type === 'MemberExpression') {
+      var prop = relevantNode.callee.property.name;
+
+      var check = nonChainingMethods[prop];
+      if (check === true || (typeof check === 'function' && check(relevantNode))) {
+        validChain = false;
+      }
+
+      relevantNode = relevantNode.callee.object;
+    }
+
+    var isjQueryStart = isjQueryStartValue(relevantNode);
+    var definiteNo = isjQueryStart && !validChain;
+    return {
+      definite: isjQueryStart && validChain,
+      possible: !definiteNo && ((isjQueryStart && node.type === 'Identifier') || isCallExpression(node)),
+    };
+  }
+
+  function checkForValidjQueryReference(node, left, right) {
+    if (right == null) { return; }
+    var isjQueryRef = isjQueryReference(left);
+    var isjQueryVal = isjQueryValue(right);
+
+    if (isjQueryRef && !isjQueryVal.possible) {
+      context.report(node, 'Don’t use a $-prefixed identifier for a non-jQuery value.');
+    } else if (!isjQueryRef && isjQueryVal.definite) {
+      context.report(node, 'Use a $-prefixed identifier for a jQuery value.');
+    }
+  }
+
+  function handleVariableDeclarator(node) {
+    checkForValidjQueryReference(node, node.id, node.init);
+  }
+
+  function handleAssignmentExpression(node) {
+    if (node.left.type === 'MemberExpression' && node.left.computed && node.left.property.type !== 'Literal') {
+      return;
+    }
+
+    checkForValidjQueryReference(node, node.left, node.right);
+  }
+
+  function handleObjectExpression(node) {
+    node.properties.forEach(function(prop) {
+      if (prop.computed && prop.key.type !== 'Literal') {
+        return;
+      }
+
+      checkForValidjQueryReference(prop, prop.key, prop.value);
+    });
+  }
+
+  function handleClassProperty(node) {
+    var tokens = context.getFirstTokens(node, 2).filter(function(token) {
+      return token.type === 'Identifier';
+    });
+
+    var id = tokens[tokens.length - 1];
+    var fakeIdentifier = Object.create(id, {
+      name: {get: function() { return this.value; }},
+    });
+
+    checkForValidjQueryReference(node, fakeIdentifier, node.value);
+  }
+
+  return {
+    VariableDeclarator: handleVariableDeclarator,
+    AssignmentExpression: handleAssignmentExpression,
+    ObjectExpression: handleObjectExpression,
+    ClassProperty: handleClassProperty,
+    // Program: function(node) { console.log(node); }
+  };
+};
+
+module.exports.schema = [
+    // fill in your schema
+];

--- a/packages/eslint-plugin-shopify/lib/rules/no-useless-computed-properties.js
+++ b/packages/eslint-plugin-shopify/lib/rules/no-useless-computed-properties.js
@@ -1,0 +1,19 @@
+module.exports = function(context) {
+  function hasLiteralComputedKey(prop) {
+    return prop.computed && (prop.key.type === 'Literal');
+  }
+
+  function checkProperty(node) {
+    if (hasLiteralComputedKey(node)) {
+      context.report({
+        node: node,
+        message: 'Computed property is using a literal key unnecessarily. Use the key directly.',
+      });
+    }
+  }
+
+  return {
+    MethodDefinition: checkProperty,
+    Property: checkProperty,
+  };
+};

--- a/packages/eslint-plugin-shopify/lib/rules/prefer-early-return.js
+++ b/packages/eslint-plugin-shopify/lib/rules/prefer-early-return.js
@@ -39,15 +39,12 @@ module.exports = function(context) {
   };
 };
 
-module.exports.schema = [
-  {
-    type: 'object',
-    properties: {
-      maximumStatements: {
-        type: 'integer',
-        default: defaultMaximumStatements,
-      },
+module.exports.schema = [{
+  type: 'object',
+  properties: {
+    maximumStatements: {
+      type: 'integer',
     },
-    additionalProperties: false,
   },
-];
+  additionalProperties: false,
+}];

--- a/packages/eslint-plugin-shopify/lib/rules/prefer-early-return.js
+++ b/packages/eslint-plugin-shopify/lib/rules/prefer-early-return.js
@@ -1,0 +1,53 @@
+var defaultMaximumStatements = 1;
+
+module.exports = function(context) {
+  var options = context.options[0] || {maximumStatements: defaultMaximumStatements};
+  var maxStatements = options.maximumStatements;
+
+  function isLonelyIfStatement(statement) {
+    return statement.type === 'IfStatement' && statement.alternate == null;
+  }
+
+  function isOffendingIfStatement(statement) {
+    return (
+      isLonelyIfStatement(statement) &&
+      statement.consequent.body.length > maxStatements
+    );
+  }
+
+  function hasSimplifiableConditionalBody(functionBody) {
+    var body = functionBody.body;
+    return (
+      functionBody.type === 'BlockStatement' &&
+      body.length === 1 &&
+      isOffendingIfStatement(body[0])
+    );
+  }
+
+  function checkFunctionBody(functionNode) {
+    var body = functionNode.body;
+
+    if (hasSimplifiableConditionalBody(body)) {
+      context.report(body, 'Prefer an early return to a conditionally-wrapped function body');
+    }
+  }
+
+  return {
+    FunctionDeclaration: checkFunctionBody,
+    FunctionExpression: checkFunctionBody,
+    ArrowFunctionExpression: checkFunctionBody,
+  };
+};
+
+module.exports.schema = [
+  {
+    type: 'object',
+    properties: {
+      maximumStatements: {
+        type: 'integer',
+        default: defaultMaximumStatements,
+      },
+    },
+    additionalProperties: false,
+  },
+];

--- a/packages/eslint-plugin-shopify/lib/rules/restrict-full-import.js
+++ b/packages/eslint-plugin-shopify/lib/rules/restrict-full-import.js
@@ -1,0 +1,90 @@
+module.exports = function(context) {
+  var restricted = context.options[0] || [];
+
+  function isRestrictedModule(mod) {
+    return restricted.indexOf(mod) >= 0;
+  }
+
+  function isPotentiallyProblematicLeft(left) {
+    return left.type === 'Identifier' ||
+      (
+        left.type === 'ObjectPattern' && left.properties.some(function(prop) {
+          return prop.type === 'SpreadProperty' || prop.type === 'ExperimentalRestProperty';
+        })
+      ) ||
+      (
+        left.type === 'ArrayPattern' && left.elements.some(function(element) {
+          return element.type === 'RestElement';
+        })
+      );
+  }
+
+  function isPotentiallyProblematicRight(right) {
+    return right &&
+      right.type === 'CallExpression' &&
+      right.callee.type === 'Identifier' &&
+      right.callee.name === 'require' &&
+      isRestrictedModule(right.arguments[0].value);
+  }
+
+  function isFullImportSpecifier(specifier) {
+    return specifier.type === 'ImportDefaultSpecifier' ||
+      specifier.type === 'ImportNamespaceSpecifier' ||
+      (specifier.type === 'ImportSpecifier' && specifier.imported.name === 'default');
+  }
+
+  function hasFullImport(specifiers) {
+    return specifiers.some(isFullImportSpecifier);
+  }
+
+  function checkImportDeclaration(node) {
+    var specifiers = node.specifiers;
+
+    if (
+      isRestrictedModule(node.source.value) &&
+      hasFullImport(specifiers)
+    ) {
+      context.report({
+        node: specifiers.length > 1 ? specifiers.find(isFullImportSpecifier) : node,
+        message: 'Unexpected full import of restricted module \'' + node.source.value + '\'.',
+      });
+    }
+  }
+
+  function checkRequire(node, left, right) {
+    if (
+      isPotentiallyProblematicLeft(left) &&
+      isPotentiallyProblematicRight(right)
+    ) {
+      context.report({
+        node: node,
+        message: 'Unexpected full import of restricted module \'' + right.arguments[0].value + '\'.',
+      });
+    }
+  }
+
+  function checkVariableDeclarator(node) {
+    checkRequire(node, node.id, node.init);
+  }
+
+  function checkAssignmentExpression(node) {
+    checkRequire(node, node.left, node.right);
+  }
+
+  return {
+    ImportDeclaration: checkImportDeclaration,
+    VariableDeclarator: checkVariableDeclarator,
+    AssignmentExpression: checkAssignmentExpression,
+  };
+
+};
+
+module.exports.schema = [{
+  restricted: {
+    type: 'array',
+    items: {
+      type: 'string',
+    },
+    uniqueItems: true,
+  },
+}];

--- a/packages/eslint-plugin-shopify/lib/rules/sinon-no-restricted-features.js
+++ b/packages/eslint-plugin-shopify/lib/rules/sinon-no-restricted-features.js
@@ -1,0 +1,61 @@
+function createSinonMatcher(aliases, injected) {
+  return function(object) {
+    return (injected && object.type === 'ThisExpression') ||
+      (object.type === 'Identifier' && aliases.indexOf(object.name) >= 0);
+  };
+}
+
+function createPropertyMatcher(properties) {
+  return function(property) {
+    return property.type === 'Identifier' && properties.indexOf(property.name) >= 0;
+  };
+}
+
+module.exports = function(context) {
+  var options = context.options[0] || {};
+  var restricted = options.restricted || [];
+  var aliases = options.aliases || ['sinon'];
+  var injected = options.injected || false;
+
+  var sinonMatcher = createSinonMatcher(aliases, injected);
+  var propertyMatcher = createPropertyMatcher(restricted);
+
+  function checkMemberExpression(node) {
+    if (sinonMatcher(node.object) && propertyMatcher(node.property)) {
+      context.report({
+        node: node,
+        message: 'Unexpected use of sinon.' + node.property.name + '.',
+      });
+    }
+  }
+
+  return {
+    MemberExpression: checkMemberExpression,
+  };
+};
+
+module.exports.schema = [{
+  type: 'object',
+  properties: {
+    restricted: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      uniqueItems: true,
+    },
+
+    aliases: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      uniqueItems: true,
+    },
+
+    injected: {
+      type: 'boolean',
+    },
+  },
+  additionalProperties: false,
+}];

--- a/packages/eslint-plugin-shopify/lib/rules/sinon-prefer-meaningful-assertions.js
+++ b/packages/eslint-plugin-shopify/lib/rules/sinon-prefer-meaningful-assertions.js
@@ -1,0 +1,116 @@
+// see http://sinonjs.org/docs/#assertions
+var SINON_ASSERT = [
+  'alwaysCalledOn',
+  'alwaysCalledWith',
+  'alwaysCalledWithExactly',
+  'alwaysCalledWithMatch',
+  'alwaysThrew',
+  'callCount',
+  'called',
+  'calledOn',
+  'calledOnce',
+  'calledThrice',
+  'calledTwice',
+  'calledWith',
+  'calledWithExactly',
+  'calledWithMatch',
+  'callOrder',
+  'neverCalledWith',
+  'neverCalledWithMatch',
+  'notCalled',
+  'threw',
+];
+
+// see https://github.com/domenic/sinon-chai
+var SINON_CHAI = [
+  'alwaysCalledOn',
+  'alwaysCalledWith',
+  'alwaysCalledWithExactly',
+  'alwaysCalledWithMatch',
+  'alwaysCalledWithNew',
+  'alwaysReturned',
+  'alwaysThrew',
+  'callCount',
+  'called',
+  'calledAfter',
+  'calledBefore',
+  'calledOn',
+  'calledOnce',
+  'calledThrice',
+  'calledTwice',
+  'calledWith',
+  'calledWithExactly',
+  'calledWithMatch',
+  'calledWithNew',
+  'notCalled',
+  'returned',
+  'threw',
+];
+
+var PREFER_SINON_CHAI_MESSAGE = 'Use the more meaningful sinon-chai assertions.';
+var PREFER_SINON_ASSERT_MESSAGE = 'Use the more meaningful sinon.assert assertions.';
+
+module.exports = function(context) {
+  function getNearestFullExpression(node) {
+    while (node.parent && node.parent.type === 'MemberExpression' || node.parent.type === 'CallExpression') {
+      node = node.parent;
+    }
+
+    return node;
+  }
+
+  function isAssertExpression(node) {
+    return node.type === 'MemberExpression' &&
+      node.object.name === 'assert';
+  }
+
+  function isRewritableSinonExpression(node, methods) {
+    return (node.type === 'MemberExpression' && methods.indexOf(node.property.name) >= 0) ||
+      (node.type === 'CallExpression' && isRewritableSinonExpression(node.callee, methods));
+  }
+
+  function isInvalidAssertCallExpression(node) {
+    return isAssertExpression(node.callee) && node.arguments.some(function(arg) {
+      return isRewritableSinonExpression(arg, SINON_ASSERT);
+    });
+  }
+
+  function isInvalidShouldExpression(node) {
+    return node.property.name === 'should' && isRewritableSinonExpression(node.object, SINON_CHAI);
+  }
+
+  function isInvalidExpectCallExpression(node) {
+    return node.callee.name === 'expect' &&
+      isRewritableSinonExpression(node.arguments[0], SINON_CHAI);
+  }
+
+  function handleCallExpression(node) {
+    if (isInvalidAssertCallExpression(node)) {
+      context.report({
+        node: node,
+        message: PREFER_SINON_ASSERT_MESSAGE,
+      });
+    }
+
+    if (isInvalidExpectCallExpression(node)) {
+      context.report({
+        node: getNearestFullExpression(node),
+        message: PREFER_SINON_CHAI_MESSAGE,
+      });
+    }
+  }
+
+  function handleMemberExpression(node) {
+    if (isInvalidShouldExpression(node)) {
+      context.report({
+        node: getNearestFullExpression(node),
+        message: PREFER_SINON_CHAI_MESSAGE,
+      });
+    }
+  }
+
+  return {
+    CallExpression: handleCallExpression,
+    MemberExpression: handleMemberExpression,
+  };
+};

--- a/packages/eslint-plugin-shopify/tests/.eslintrc.js
+++ b/packages/eslint-plugin-shopify/tests/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: 'plugin:shopify/esnext',
+};

--- a/packages/eslint-plugin-shopify/tests/lib/rules/binary-assignment-parens.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/binary-assignment-parens.js
@@ -1,36 +1,36 @@
-var rule = require('../../../lib/rules/binary-assignment-parens');
-var RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/binary-assignment-parens');
+const RuleTester = require('eslint').RuleTester;
 
-var ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
 
-var NON_BOOLEAN_OPERATORS = ['-', '+', '*', '/', '||', '&&'];
-var BOOLEAN_OPERATORS = ['==', '===', '!=', '!==', '>', '>=', '<', '<='];
+const NON_BOOLEAN_OPERATORS = ['-', '+', '*', '/', '||', '&&'];
+const BOOLEAN_OPERATORS = ['==', '===', '!=', '!==', '>', '>=', '<', '<='];
 
-var validNonBooleanExamples = [].concat.apply([], NON_BOOLEAN_OPERATORS.map(function(operator) {
-  return [
-    {code: "var foo = 'bar' " + operator + " 'baz';"},
-    {code: "var foo = 'bar' " + operator + " 'baz';", options: ['never']},
-    {code: "var foo = ('bar' " + operator + " 'baz');"},
-    {code: "var foo = ('bar' " + operator + " 'baz');", options: ['never']},
-    {code: "var foo = ( 'bar' " + operator + " 'baz' );"},
-    {code: "var foo = ( 'bar' " + operator + " 'baz' );", options: ['never']},
-    {code: "var foo; foo = 'bar' " + operator + " 'baz';"},
-    {code: "var foo; foo = ('bar' " + operator + " 'baz');", options: ['never']},
-  ];
-}));
+const validNonBooleanExamples = [].concat(...NON_BOOLEAN_OPERATORS.map((operator) => (
+  [
+    {code: `var foo = 'bar' ${operator} 'baz';`},
+    {code: `var foo = 'bar' ${operator} 'baz';`, options: ['never']},
+    {code: `var foo = ('bar' ${operator} 'baz');`},
+    {code: `var foo = ('bar' ${operator} 'baz');`, options: ['never']},
+    {code: `var foo = ( 'bar' ${operator} 'baz' );`},
+    {code: `var foo = ( 'bar' ${operator} 'baz' );`, options: ['never']},
+    {code: `var foo; foo = 'bar' ${operator} 'baz';`},
+    {code: `var foo; foo = ('bar' ${operator} 'baz');`, options: ['never']},
+  ]
+)));
 
-var validBooleanExamples = [].concat.apply([], BOOLEAN_OPERATORS.map(function(operator) {
-  return [
-    {code: "var foo = ('bar' " + operator + " 'baz')"},
-    {code: "var foo = ( 'bar' " + operator + " 'baz' )"},
-    {code: "var foo = 'bar' " + operator + " 'baz'", options: ['never']},
-    {code: "var foo; foo = ('bar' " + operator + " 'baz')"},
-    {code: "var foo; foo = ( 'bar' " + operator + " 'baz' )"},
-    {code: "var foo; foo = 'bar' " + operator + " 'baz'", options: ['never']},
-  ];
-}));
+const validBooleanExamples = [].concat(...BOOLEAN_OPERATORS.map((operator) => (
+  [
+    {code: `var foo = ('bar' ${operator} 'baz')`},
+    {code: `var foo = ( 'bar' ${operator} 'baz' )`},
+    {code: `var foo = 'bar' ${operator} 'baz'`, options: ['never']},
+    {code: `var foo; foo = ('bar' ${operator} 'baz')`},
+    {code: `var foo; foo = ( 'bar' ${operator} 'baz' )`},
+    {code: `var foo; foo = 'bar' ${operator} 'baz'`, options: ['never']},
+  ]
+)));
 
-var validLogicalExamples = [
+const validLogicalExamples = [
   {code: "var foo = ('bar' !== 'bar') || ('baz' === 'baz');"},
   {code: "var foo = ( 'bar' !== 'bar' ) || ( 'baz' === 'baz' );"},
   {code: "var foo = ('bar' !== 'bar') || ('baz' === 'baz') && qux;"},
@@ -54,10 +54,10 @@ var validLogicalExamples = [
   {code: "var foo; foo = 'bar' !== 'bar' || qux;", options: ['never']},
 ];
 
-var invalidBooleanExamples = [].concat.apply([], BOOLEAN_OPERATORS.map(function(operator) {
-  return [
+const invalidBooleanExamples = [].concat(...BOOLEAN_OPERATORS.map((operator) => (
+  [
     {
-      code: "var foo = 'bar' " + operator + " 'baz'",
+      code: `var foo = 'bar' ${operator} 'baz'`,
       errors: [{
         message: 'You must include parentheses around a binary assignment expression.',
         type: 'BinaryExpression',
@@ -65,7 +65,7 @@ var invalidBooleanExamples = [].concat.apply([], BOOLEAN_OPERATORS.map(function(
     },
 
     {
-      code: "var foo = ('bar' " + operator + " 'baz')",
+      code: `var foo = ('bar' ${operator} 'baz')`,
       options: ['never'],
       errors: [{
         message: 'You must not include parentheses around a binary assignment expression.',
@@ -74,7 +74,7 @@ var invalidBooleanExamples = [].concat.apply([], BOOLEAN_OPERATORS.map(function(
     },
 
     {
-      code: "var foo = ( 'bar' " + operator + " 'baz' )",
+      code: `var foo = ( 'bar' ${operator} 'baz' )`,
       options: ['never'],
       errors: [{
         message: 'You must not include parentheses around a binary assignment expression.',
@@ -83,7 +83,7 @@ var invalidBooleanExamples = [].concat.apply([], BOOLEAN_OPERATORS.map(function(
     },
 
     {
-      code: "var foo; foo = 'bar' " + operator + " 'baz'",
+      code: `var foo; foo = 'bar' ${operator} 'baz'`,
       errors: [{
         message: 'You must include parentheses around a binary assignment expression.',
         type: 'BinaryExpression',
@@ -91,7 +91,7 @@ var invalidBooleanExamples = [].concat.apply([], BOOLEAN_OPERATORS.map(function(
     },
 
     {
-      code: "var foo; foo = ('bar' " + operator + " 'baz')",
+      code: `var foo; foo = ('bar' ${operator} 'baz')`,
       options: ['never'],
       errors: [{
         message: 'You must not include parentheses around a binary assignment expression.',
@@ -100,32 +100,33 @@ var invalidBooleanExamples = [].concat.apply([], BOOLEAN_OPERATORS.map(function(
     },
 
     {
-      code: "var foo; foo = ( 'bar' " + operator + " 'baz' )",
+      code: `var foo; foo = ( 'bar' ${operator} 'baz' )`,
       options: ['never'],
       errors: [{
         message: 'You must not include parentheses around a binary assignment expression.',
         type: 'BinaryExpression',
       }],
     },
-  ];
-}));
+  ]
+)));
 
 function errors(count, needsParens) {
-  var err = [];
+  const err = [];
 
+  // eslint-disable-next-line no-var
   for (var index = 0; index < count; index++) {
     err.push({
       type: 'BinaryExpression',
-      message: (needsParens
+      message: needsParens
         ? 'You must include parentheses around a binary assignment expression.'
-        : 'You must not include parentheses around a binary assignment expression.'),
+        : 'You must not include parentheses around a binary assignment expression.',
     });
   }
 
   return err;
 }
 
-var invalidLogicalExamples = [
+const invalidLogicalExamples = [
   {code: "var foo = ('bar' !== 'bar') || ('baz' === 'baz');", options: ['never'], errors: errors(2, false)},
   {code: "var foo = ( 'bar' !== 'bar' ) || ( 'baz' === 'baz' );", options: ['never'], errors: errors(2, false)},
   {code: "var foo = ('bar' !== 'bar') || ('baz' === 'baz') && qux;", options: ['never'], errors: errors(2, false)},

--- a/packages/eslint-plugin-shopify/tests/lib/rules/class-property-semi.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/class-property-semi.js
@@ -1,0 +1,77 @@
+const rule = require('../../../lib/rules/class-property-semi');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+require('babel-eslint');
+
+const classPropNoSemi = 'class Foo { bar = 1 }';
+const classPropWithSemi = 'class Foo { bar = 1; }';
+const classStaticPropNoSemi = 'class Foo { static bar = 1 }';
+const classStaticPropWithSemi = 'class Foo { static bar = 1; }';
+const classMethod = 'class Foo { bar() {} }';
+
+ruleTester.run('class-property-semi', rule, {
+  valid: [
+    {code: classPropWithSemi, parser: 'babel-eslint'},
+    {code: classPropWithSemi, parser: 'babel-eslint', options: ['always']},
+    {code: classPropNoSemi, parser: 'babel-eslint', options: ['never']},
+    {code: classStaticPropWithSemi, parser: 'babel-eslint'},
+    {code: classStaticPropWithSemi, parser: 'babel-eslint', options: ['always']},
+    {code: classStaticPropNoSemi, parser: 'babel-eslint', options: ['never']},
+    {code: classMethod, parserOptions: {ecmaVersion: 6}},
+  ],
+  invalid: [
+    {
+      code: classPropNoSemi,
+      parser: 'babel-eslint',
+      errors: [{
+        message: 'Missing semicolon.',
+        type: 'ClassProperty',
+      }],
+    },
+    {
+      code: classPropNoSemi,
+      parser: 'babel-eslint',
+      options: ['always'],
+      errors: [{
+        message: 'Missing semicolon.',
+        type: 'ClassProperty',
+      }],
+    },
+    {
+      code: classPropWithSemi,
+      parser: 'babel-eslint',
+      options: ['never'],
+      errors: [{
+        message: 'Extra semicolon.',
+        type: 'ClassProperty',
+      }],
+    },
+    {
+      code: classStaticPropNoSemi,
+      parser: 'babel-eslint',
+      errors: [{
+        message: 'Missing semicolon.',
+        type: 'ClassProperty',
+      }],
+    },
+    {
+      code: classStaticPropNoSemi,
+      parser: 'babel-eslint',
+      options: ['always'],
+      errors: [{
+        message: 'Missing semicolon.',
+        type: 'ClassProperty',
+      }],
+    },
+    {
+      code: classStaticPropWithSemi,
+      parser: 'babel-eslint',
+      options: ['never'],
+      errors: [{
+        message: 'Extra semicolon.',
+        type: 'ClassProperty',
+      }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-shopify/tests/lib/rules/jquery-dollar-sign-reference.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/jquery-dollar-sign-reference.js
@@ -1,0 +1,529 @@
+const rule = require('../../../lib/rules/jquery-dollar-sign-reference');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+require('babel-eslint');
+
+function missingDollarError(otherAttrs) {
+  otherAttrs.message = 'Use a $-prefixed identifier for a jQuery value.';
+  return otherAttrs;
+}
+
+function unexpectedDollarError(otherAttrs) {
+  otherAttrs.message = 'Don’t use a $-prefixed identifier for a non-jQuery value.';
+  return otherAttrs;
+}
+
+ruleTester.run('jquery-dollar-sign-reference', rule, {
+  valid: [
+    {code: 'var $foo = $("foo");'},
+    {code: 'var $foo = $bar;'},
+    {code: 'var $foo = jQuery("foo");'},
+    {code: 'var $foo = something();'},
+    {code: 'var $foo = something.else();'},
+    {code: 'var foo = "something";'},
+    {code: 'var foo = "$bar";'},
+    {code: 'var foo = something();'},
+    {code: 'var foo = bar;'},
+
+    {code: 'this.$foo = $("foo");'},
+    {code: 'this.$foo = $bar;'},
+    {code: 'this.$foo = jQuery("foo");'},
+    {code: 'this.$foo = something();'},
+    {code: 'this.$foo = something.else();'},
+    {code: 'this.foo = "something";'},
+    {code: 'this.foo = "$bar";'},
+    {code: 'this.foo = something();'},
+    {code: 'this.foo = bar;'},
+
+    {code: 'this["$foo"] = $("foo");'},
+    {code: 'this["$foo"] = $bar;'},
+    {code: 'this["$foo"] = jQuery("foo");'},
+    {code: 'this["$foo"] = something();'},
+    {code: 'this["$foo"] = something.else();'},
+    {code: 'this["foo"] = "something";'},
+    {code: 'this["foo"] = "$bar";'},
+    {code: 'this["foo"] = something();'},
+    {code: 'this["foo"] = bar;'},
+
+    {code: 'this[foo] = $("foo");'},
+    {code: 'this[foo()] = $("foo");'},
+    {code: 'this[foo] = something;'},
+    {code: 'this[foo()] = something;'},
+
+    {code: 'obj = {$foo: $("foo")}'},
+    {code: 'obj = {$foo: $bar}'},
+    {code: 'obj = {$foo: jQuery("foo")}'},
+    {code: 'obj = {$foo: something()}'},
+    {code: 'obj = {$foo: something.else()}'},
+    {code: 'obj = {foo: "something"}'},
+    {code: 'obj = {foo: "$bar"}'},
+    {code: 'obj = {foo: something()}'},
+    {code: 'obj = {foo: bar}'},
+
+    {code: 'var $foo; $foo = $("foo");'},
+    {code: 'var $foo; $foo = $bar;'},
+    {code: 'var $foo; $foo = jQuery("foo");'},
+    {code: 'var $foo; $foo = something();'},
+    {code: 'var $foo; $foo = something.else();'},
+    {code: 'var foo; foo = "something";'},
+    {code: 'var foo; foo = "$bar";'},
+    {code: 'var foo; foo = something();'},
+    {code: 'var foo; foo = bar;'},
+
+    {
+      code: 'var [$foo, bar] = baz;',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'var {$foo, bar} = baz;',
+      parser: 'babel-eslint',
+    },
+
+    {
+      code: 'class Foo { static $foo = $("foo"); }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { static $foo = $bar; }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { static $foo = jQuery("foo"); }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { static $foo = something(); }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { static $foo = something.else(); }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { static foo = "something"; }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { static foo = "$bar"; }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { static foo = something(); }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { static foo = bar; }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { $foo = $("foo"); }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { $foo = $bar; }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { $foo = jQuery("foo"); }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { $foo = something(); }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { $foo = something.else(); }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { foo = "something"; }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { foo = "$bar"; }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { foo = something(); }',
+      parser: 'babel-eslint',
+    },
+    {
+      code: 'class Foo { foo = bar; }',
+      parser: 'babel-eslint',
+    },
+
+    {code: 'var $foo = $("foo").addClass("bar").removeClass("baz");'},
+    {code: 'var $foo = $("foo").baz().qux();'},
+    {code: 'var $foo = jQuery("foo").addClass("bar").removeClass("baz");'},
+    {code: 'var $foo = jQuery("foo").baz().qux();'},
+    {code: 'var $foo = $bar.addClass("bar").removeClass("baz");'},
+    {code: 'var $foo = $bar.baz().qux();'},
+    {code: 'var foo = other("foo").addClass("bar").removeClass("baz");'},
+    {code: 'var foo = other("foo").baz().qux();'},
+    {code: 'var foo = bar.addClass("bar").removeClass("baz");'},
+    {code: 'var foo = bar.baz().qux();'},
+    {code: 'var foo = $.ajax().onFail();'},
+    {code: 'var foo = $.version;'},
+
+    {code: 'var $foo = $bar.attr({});'},
+    {code: 'var $foo = $bar.attr(key, val);'},
+    {code: 'var $foo = $bar.prop({});'},
+    {code: 'var $foo = $bar.prop(key, val);'},
+    {code: 'var $foo = $bar.data({});'},
+    {code: 'var $foo = $bar.data(key, val);'},
+    {code: 'var $foo = $bar.html("<div />");'},
+    {code: 'var foo = $bar.attr(key);'},
+    {code: 'var foo = $bar.prop(key);'},
+    {code: 'var foo = $bar.data(key);'},
+    {code: 'var foo = $bar.html();'},
+
+    {code: 'var foo = $bar.context();'},
+    {code: 'var foo = $bar.get();'},
+    {code: 'var foo = $bar.hasClass();'},
+    {code: 'var foo = $bar.height();'},
+    {code: 'var foo = $bar.index();'},
+    {code: 'var foo = $bar.innerHeight();'},
+    {code: 'var foo = $bar.innerWidth();'},
+    {code: 'var foo = $bar.is();'},
+    {code: 'var foo = $bar.offset();'},
+    {code: 'var foo = $bar.outerHeight();'},
+    {code: 'var foo = $bar.outerWidth();'},
+    {code: 'var foo = $bar.position();'},
+    {code: 'var foo = $bar.promise();'},
+    {code: 'var foo = $bar.scrollLeft();'},
+    {code: 'var foo = $bar.scrollTop();'},
+    {code: 'var foo = $bar.serialize();'},
+    {code: 'var foo = $bar.serializeArray();'},
+    {code: 'var foo = $bar.size();'},
+    {code: 'var foo = $bar.text();'},
+    {code: 'var foo = $bar.toArray();'},
+    {code: 'var foo = $bar.triggerHandler();'},
+    {code: 'var foo = $bar.val();'},
+    {code: 'var foo = $bar.width();'},
+  ],
+  invalid: [
+    {
+      code: 'var foo = $("foo");',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = $bar;',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = jQuery("foo");',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = "something";',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = bar;',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+
+    {
+      code: 'this.foo = $("foo");',
+      errors: [missingDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'this.foo = $bar;',
+      errors: [missingDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'this.foo = jQuery("foo");',
+      errors: [missingDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'this.$foo = "something";',
+      errors: [unexpectedDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'this.$foo = bar;',
+      errors: [unexpectedDollarError({type: 'AssignmentExpression'})],
+    },
+
+    {
+      code: 'this["foo"] = $("foo");',
+      errors: [missingDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'this["foo"] = $bar;',
+      errors: [missingDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'this["foo"] = jQuery("foo");',
+      errors: [missingDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'this["$foo"] = "something";',
+      errors: [unexpectedDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'this["$foo"] = bar;',
+      errors: [unexpectedDollarError({type: 'AssignmentExpression'})],
+    },
+
+    {
+      code: 'obj = {foo: $("foo")};',
+      errors: [missingDollarError({type: 'Property'})],
+    },
+    {
+      code: 'obj = {foo: $bar};',
+      errors: [missingDollarError({type: 'Property'})],
+    },
+    {
+      code: 'obj = {foo: jQuery("foo")};',
+      errors: [missingDollarError({type: 'Property'})],
+    },
+    {
+      code: 'obj = {$foo: "something"};',
+      errors: [unexpectedDollarError({type: 'Property'})],
+    },
+    {
+      code: 'obj = {$foo: bar};',
+      errors: [unexpectedDollarError({type: 'Property'})],
+    },
+
+    {
+      code: 'var foo; foo = $("foo");',
+      errors: [missingDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'var foo; foo = $bar;',
+      errors: [missingDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'var foo; foo = jQuery("foo");',
+      errors: [missingDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'var $foo; $foo = "something";',
+      errors: [unexpectedDollarError({type: 'AssignmentExpression'})],
+    },
+    {
+      code: 'var $foo; $foo = bar;',
+      errors: [unexpectedDollarError({type: 'AssignmentExpression'})],
+    },
+
+    {
+      code: 'class Foo { static foo = $("foo"); }',
+      parser: 'babel-eslint',
+      errors: [missingDollarError({type: 'ClassProperty'})],
+    },
+    {
+      code: 'class Foo { static foo = $bar; }',
+      parser: 'babel-eslint',
+      errors: [missingDollarError({type: 'ClassProperty'})],
+    },
+    {
+      code: 'class Foo { static foo = jQuery("foo"); }',
+      parser: 'babel-eslint',
+      errors: [missingDollarError({type: 'ClassProperty'})],
+    },
+    {
+      code: 'class Foo { static $foo = "something"; }',
+      parser: 'babel-eslint',
+      errors: [unexpectedDollarError({type: 'ClassProperty'})],
+    },
+    {
+      code: 'class Foo { static $foo = bar; }',
+      parser: 'babel-eslint',
+      errors: [unexpectedDollarError({type: 'ClassProperty'})],
+    },
+    {
+      code: 'class Foo { foo = $("foo"); }',
+      parser: 'babel-eslint',
+      errors: [missingDollarError({type: 'ClassProperty'})],
+    },
+    {
+      code: 'class Foo { foo = $bar; }',
+      parser: 'babel-eslint',
+      errors: [missingDollarError({type: 'ClassProperty'})],
+    },
+    {
+      code: 'class Foo { foo = jQuery("foo"); }',
+      parser: 'babel-eslint',
+      errors: [missingDollarError({type: 'ClassProperty'})],
+    },
+    {
+      code: 'class Foo { $foo = "something"; }',
+      parser: 'babel-eslint',
+      errors: [unexpectedDollarError({type: 'ClassProperty'})],
+    },
+    {
+      code: 'class Foo { $foo = bar; }',
+      parser: 'babel-eslint',
+      errors: [unexpectedDollarError({type: 'ClassProperty'})],
+    },
+
+    {
+      code: 'var foo = $("foo").addClass("bar").removeClass("baz");',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = $("foo").baz().qux();',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = jQuery("foo").addClass("bar").removeClass("baz");',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = jQuery("foo").baz().qux();',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = $bar.addClass("bar").removeClass("baz");',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = $bar.baz().qux();',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $.version;',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+
+    {
+      code: 'var foo = $bar.attr({});',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = $bar.attr(key, val);',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = $bar.prop({});',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = $bar.prop(key, val);',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = $bar.data({});',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = $bar.data(key, val);',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = $bar.html("<div />");',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.attr(key);',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.prop(key);',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.data(key);',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.html();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+
+    {
+      code: 'var $foo = $bar.context();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.get();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.hasClass();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.height();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.index();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.innerHeight();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.innerWidth();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.is();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.offset();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.outerHeight();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.outerWidth();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.position();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.promise();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.scrollLeft();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.scrollTop();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.serialize();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.serializeArray();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.size();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.text();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.toArray();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.triggerHandler();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.val();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = $bar.width();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+  ],
+});

--- a/packages/eslint-plugin-shopify/tests/lib/rules/no-useless-computed-properties.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/no-useless-computed-properties.js
@@ -1,0 +1,81 @@
+const rule = require('../../../lib/rules/no-useless-computed-properties');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+require('babel-eslint');
+
+const parserOptions = {ecmaVersion: 6};
+const message = 'Computed property is using a literal key unnecessarily. Use the key directly.';
+
+ruleTester.run('no-useless-computed-properties', rule, {
+  valid: [
+    {code: 'var foo = {"bar": true}'},
+    {code: 'var foo = {bar: true}'},
+    {code: 'var foo = {[bar]: true}', parserOptions},
+    {code: 'var foo = {[bar()]: true}', parserOptions},
+    {code: 'var foo = {123: true}'},
+
+    {code: 'var foo = {"bar"() {}}', parserOptions},
+    {code: 'var foo = {bar() {}}', parserOptions},
+    {code: 'var foo = {[bar]() {}}', parserOptions},
+    {code: 'var foo = {[bar()]() {}}', parserOptions},
+    {code: 'var foo = {123() {}}', parserOptions},
+
+    {code: 'class Foo {"bar"() {}}', parserOptions},
+    {code: 'class Foo {bar() {}}', parserOptions},
+    {code: 'class Foo {[bar]() {}}', parserOptions},
+    {code: 'class Foo {[bar()]() {}}', parserOptions},
+    {code: 'class Foo {123() {}}', parserOptions},
+
+    {code: 'class Foo {static "bar"() {}}', parser: 'babel-eslint'},
+    {code: 'class Foo {static bar() {}}', parser: 'babel-eslint'},
+    {code: 'class Foo {static [bar]() {}}', parser: 'babel-eslint'},
+    {code: 'class Foo {static [bar()]() {}}', parser: 'babel-eslint'},
+    {code: 'class Foo {static 123() {}}', parser: 'babel-eslint'},
+  ],
+  invalid: [
+    {
+      code: 'var foo = {["bar"]: true}',
+      parserOptions,
+      errors: [{message, type: 'Property'}],
+    },
+    {
+      code: 'var foo = {[123]: true}',
+      parserOptions,
+      errors: [{message, type: 'Property'}],
+    },
+
+    {
+      code: 'var foo = {["bar"]() {}}',
+      parserOptions,
+      errors: [{message, type: 'Property'}],
+    },
+    {
+      code: 'var foo = {[123]() {}}',
+      parserOptions,
+      errors: [{message, type: 'Property'}],
+    },
+
+    {
+      code: 'class Foo {["bar"]() {}}',
+      parserOptions,
+      errors: [{message, type: 'MethodDefinition'}],
+    },
+    {
+      code: 'class Foo {[123]() {}}',
+      parserOptions,
+      errors: [{message, type: 'MethodDefinition'}],
+    },
+
+    {
+      code: 'class Foo {static ["bar"]() {}}',
+      parser: 'babel-eslint',
+      errors: [{message, type: 'MethodDefinition'}],
+    },
+    {
+      code: 'class Foo {static [123]() {}}',
+      parser: 'babel-eslint',
+      errors: [{message, type: 'MethodDefinition'}],
+    },
+  ],
+});

--- a/packages/eslint-plugin-shopify/tests/lib/rules/prefer-early-return.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/prefer-early-return.js
@@ -1,0 +1,137 @@
+const rule = require('../../../lib/rules/prefer-early-return');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester();
+
+const error = {
+  message: 'Prefer an early return to a conditionally-wrapped function body',
+  type: 'BlockStatement',
+};
+
+ruleTester.run('prefer-early-return', rule, {
+  valid: [
+    {
+      code: `function foo() {
+        if (!something) { return; }
+
+        doSomething();
+        doSomethingElse();
+      }`,
+    },
+    {
+      code: `function foo() {
+        if (something) {
+          doSomething();
+        }
+      }`,
+    },
+    {
+      code: `function foo() {
+        if (something) {
+          doSomething();
+          doSomethingElse();
+        }
+      }`,
+      options: [
+        {maximumStatements: 2},
+      ],
+    },
+    {
+      code: `function foo() {
+        if (something) {
+          doSomething();
+          doSomethingElse();
+        }
+
+        someOtherThing();
+      }`,
+    },
+    {
+      code: `function foo() {
+        if (something) {
+          doSomething();
+          doSomethingElse();
+        } else {
+          doAnotherThing();
+        }
+      }`,
+    },
+    {
+      code: `var foo = function() {
+        if (something) {
+          doSomething();
+        }
+      }`,
+    },
+    {
+      code: `var foo = () => {
+        if (something) {
+          doSomething();
+        }
+      }`,
+      parserOptions: {ecmaVersion: 6},
+    },
+    {
+      code: `var foo = function() {
+        if (something) {
+          doSomething();
+        }
+      }`,
+    },
+    {
+      code: "var foo = () => 'bar'",
+      parserOptions: {ecmaVersion: 6},
+    },
+  ],
+
+  invalid: [
+    {
+      code: `function foo() {
+        if (something) {
+          doSomething();
+          doSomethingElse();
+        }
+      }`,
+      errors: [error],
+    },
+    {
+      code: `function foo() {
+        if (something) {
+          doSomething();
+        }
+      }`,
+      options: [
+        {maximumStatements: 0},
+      ],
+      errors: [error],
+    },
+    {
+      code: `var foo = function() {
+        if (something) {
+          doSomething();
+          doSomethingElse();
+        }
+      }`,
+      errors: [error],
+    },
+    {
+      code: `var foo = () => {
+        if (something) {
+          doSomething();
+          doSomethingElse();
+        }
+      }`,
+      parserOptions: {ecmaVersion: 6},
+      errors: [error],
+    },
+    {
+      code: `callback(function() {
+        if (something) {
+          doSomething();
+          doSomethingElse();
+        }
+      })`,
+      errors: [error],
+    },
+  ],
+});

--- a/packages/eslint-plugin-shopify/tests/lib/rules/require-flow.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/require-flow.js
@@ -1,13 +1,18 @@
-var rule = require('../../../lib/rules/require-flow');
-var RuleTester = require('eslint').RuleTester;
-var ruleTester = new RuleTester();
+const rule = require('../../../lib/rules/require-flow');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
 
 require('babel-eslint');
 
-var withFlow = '/* @flow */\n\nfunction yesFlow(present: boolean): string { return "success"; }';
-var explicitNoFlow = '/* @noflow */\n\nfunction yesFlow(present: boolean): string { return "success"; }';
-var noFlow = 'function noFlow(present) {}';
-var confusingFlow = 'var foo = "bar"\n\n// This is not a realy @flow comment';
+const withFlow = `/* @flow */
+function yesFlow(present: boolean): string { return 'success'; }`;
+
+const explicitNoFlow = `/* @noflow */
+function yesFlow(present: boolean): string { return 'success'; }`;
+
+const noFlow = 'function noFlow(present) {}';
+const confusingFlow = `var foo = 'bar'
+// This is not a realy @flow comment`;
 
 ruleTester.run('require-flow', rule, {
   valid: [

--- a/packages/eslint-plugin-shopify/tests/lib/rules/restrict-full-import.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/restrict-full-import.js
@@ -1,0 +1,123 @@
+const rule = require('../../../lib/rules/restrict-full-import');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+require('babel-eslint');
+
+const parserOptions = {
+  ecmaVersion: 7,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+  },
+};
+
+const options = [['lodash']];
+const message = `Unexpected full import of restricted module '${options[0][0]}'.`;
+
+ruleTester.run('restrict-full-import', rule, {
+  valid: [
+    {code: 'import {chain} from "lodash";', parserOptions, options},
+    {code: 'import _ from "something-else";', parserOptions, options},
+    {code: 'import chain from "lodash/chain";', parserOptions, options},
+    {code: 'var chain = require("lodash").chain;', options},
+    {code: 'var {chain} = require("lodash");', parserOptions, options},
+    {code: 'var chain = require("lodash/chain");', options},
+    {code: 'var _ = require("something-else");', options},
+  ],
+
+  invalid: [
+    {
+      code: 'import * as _ from "lodash";',
+      parserOptions,
+      options,
+      errors: [{
+        message,
+        type: 'ImportDeclaration',
+      }],
+    },
+    {
+      code: 'import _ from "lodash";',
+      parserOptions,
+      options,
+      errors: [{
+        message,
+        type: 'ImportDeclaration',
+      }],
+    },
+    {
+      code: 'import _, {chain} from "lodash";',
+      parserOptions,
+      options,
+      errors: [{
+        message,
+        type: 'ImportDefaultSpecifier',
+      }],
+    },
+    {
+      code: 'import {default as _, chain} from "lodash";',
+      parserOptions,
+      options,
+      errors: [{
+        message,
+        type: 'ImportSpecifier',
+      }],
+    },
+    {
+      code: 'var _ = require("lodash");',
+      parserOptions,
+      options,
+      errors: [{
+        message,
+        type: 'VariableDeclarator',
+      }],
+    },
+    {
+      code: 'var _; _ = require("lodash");',
+      parserOptions,
+      options,
+      errors: [{
+        message,
+        type: 'AssignmentExpression',
+      }],
+    },
+    {
+      code: 'var {chain, ...rest} = require("lodash");',
+      parserOptions,
+      options,
+      errors: [{
+        message,
+        type: 'VariableDeclarator',
+      }],
+    },
+    {
+      code: 'var {chain, ...rest} = require("lodash");',
+      parserOptions,
+      options,
+      parser: 'babel-eslint',
+      errors: [{
+        message,
+        type: 'VariableDeclarator',
+      }],
+    },
+    {
+      code: 'var [chain, ...rest] = require("lodash");',
+      parserOptions,
+      options,
+      errors: [{
+        message,
+        type: 'VariableDeclarator',
+      }],
+    },
+    {
+      code: 'var [chain, ...rest] = require("lodash");',
+      parserOptions,
+      options,
+      parser: 'babel-eslint',
+      errors: [{
+        message,
+        type: 'VariableDeclarator',
+      }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-shopify/tests/lib/rules/sinon-no-restricted-features.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/sinon-no-restricted-features.js
@@ -1,0 +1,35 @@
+const rule = require('../../../lib/rules/sinon-no-restricted-features');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+const sinonRestricted = 'sinon.mock().something();';
+const sinonUnrestricted = 'sinon.stub();';
+const aliasRestricted = 'sandbox.mock().something();';
+const aliasUnrestricted = 'sandbox.stub();';
+const injectRestricted = 'this.mock().something();';
+const injectUnrestricted = 'this.stub();';
+
+const restricted = ['mock'];
+const aliases = ['sandbox'];
+const errors = [{
+  message: `Unexpected use of sinon.${restricted[0]}.`,
+  type: 'MemberExpression',
+}];
+
+ruleTester.run('sinon-no-restricted-features', rule, {
+  valid: [
+    {code: sinonRestricted},
+    {code: sinonRestricted, options: [{restricted, aliases}]},
+    {code: sinonUnrestricted, options: [{restricted}]},
+    {code: aliasRestricted, options: [{restricted}]},
+    {code: aliasUnrestricted, options: [{restricted, aliases}]},
+    {code: injectRestricted, options: [{restricted, aliases}]},
+    {code: injectUnrestricted, options: [{restricted, aliases, injected: true}]},
+  ],
+
+  invalid: [
+    {code: sinonRestricted, options: [{restricted}], errors},
+    {code: aliasRestricted, options: [{restricted, aliases}], errors},
+    {code: injectRestricted, options: [{restricted, injected: true}], errors},
+  ],
+});

--- a/packages/eslint-plugin-shopify/tests/lib/rules/sinon-prefer-meaningful-assertions.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/sinon-prefer-meaningful-assertions.js
@@ -1,0 +1,79 @@
+const rule = require('../../../lib/rules/sinon-prefer-meaningful-assertions');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+function bddError(type) {
+  return [{type, message: 'Use the more meaningful sinon-chai assertions.'}];
+}
+
+const tddError = [{
+  message: 'Use the more meaningful sinon.assert assertions.',
+  type: 'CallExpression',
+}];
+
+ruleTester.run('sinon-prefer-meaningful-assertions', rule, {
+  valid: [
+    {code: 'expect(foo).to.be.true;'},
+    {code: 'expect(foo).to.equal(3);'},
+    {code: 'expect(foo).to.have.been.called;'},
+    {code: 'expect(foo).to.have.callCount(3);'},
+    {code: 'expect(foo).to.have.alwaysCalledWithNew(Foo);'},
+    {code: 'expect(foo.bar).to.have.been.called;'},
+    {code: 'expect(foo.bar.baz).to.have.been.called;'},
+    {code: 'expect(foo.bar()).to.have.been.called;'},
+
+    {code: 'expect(called).to.be.true;'},
+    {code: 'expect(callCount(3)).to.equal(3);'},
+
+    {code: 'foo.should.be.true;'},
+    {code: 'foo.should.equal(3);'},
+    {code: 'foo.should.have.been.called;'},
+    {code: 'foo.should.have.callCount(3);'},
+    {code: 'foo.should.have.alwaysCalledWithNew(Foo);'},
+    {code: 'foo.bar.should.have.been.called;'},
+    {code: 'foo.bar.baz.should.have.been.called;'},
+    {code: 'foo.bar().should.have.been.called;'},
+
+    {code: 'called.should.be.true;'},
+    {code: 'callCount(3).should.equal(3);'},
+
+    {code: 'assert.true(foo);'},
+    {code: 'assert.equal(foo, 3);'},
+    {code: 'assert.equal(3, foo);'},
+    {code: 'assert.called(foo.bar);'},
+    {code: 'assert.callCount(foo.bar.baz(), 3);'},
+    {code: 'assert.notCalled(foo.bar);'},
+    {code: 'assert.true(foo.calledWithNew());'},
+
+    {code: 'sinon.assert.called(foo.bar);'},
+    {code: 'sinon.assert.callCount(foo.bar.baz(), 3);'},
+    {code: 'sinon.assert.notCalled(foo.bar);'},
+
+    {code: 'assert.true(called);'},
+    {code: 'assert.equal(callCount, 3);'},
+  ],
+
+  invalid: [
+    {code: 'expect(foo.called).to.be.true;', errors: bddError('MemberExpression')},
+    {code: 'expect(foo.callCount).to.equal(3);', errors: bddError('CallExpression')},
+    {code: 'expect(foo.alwaysCalledWithNew()).to.be.true;', errors: bddError('MemberExpression')},
+    {code: 'expect(foo.bar.callCount).to.equal(3);', errors: bddError('CallExpression')},
+    {code: 'expect(foo.bar.alwaysCalledWithNew()).to.be.true;', errors: bddError('MemberExpression')},
+    {code: 'expect(foo.bar.baz().callCount).to.equal(3);', errors: bddError('CallExpression')},
+    {code: 'expect(foo.bar.baz().alwaysCalledWithNew()).to.be.true;', errors: bddError('MemberExpression')},
+
+    {code: 'foo.called.should.be.true;', errors: bddError('MemberExpression')},
+    {code: 'foo.callCount.should.equal(3);', errors: bddError('CallExpression')},
+    {code: 'foo.alwaysCalledWithNew().should.be.true;', errors: bddError('MemberExpression')},
+    {code: 'foo.bar.callCount.should.equal(3);', errors: bddError('CallExpression')},
+    {code: 'foo.bar.alwaysCalledWithNew().should.be.true;', errors: bddError('MemberExpression')},
+    {code: 'foo.bar.baz().callCount.should.equal(3);', errors: bddError('CallExpression')},
+    {code: 'foo.bar.baz().alwaysCalledWithNew().should.be.true;', errors: bddError('MemberExpression')},
+
+    {code: 'assert.true(foo.called);', errors: tddError},
+    {code: 'assert.equal(foo.callCount, 3);', errors: tddError},
+    {code: 'assert.equal(foo.bar.callCount, 3);', errors: tddError},
+    {code: 'assert.equal(foo.bar.baz().callCount, 3);', errors: tddError},
+    {code: 'assert.true(foo.bar.notCalled);', errors: tddError},
+  ],
+});


### PR DESCRIPTION
This PR adds two ESLint rules:

1. `jquery-dollar-sign-reference` forces you to prefix references with `$` when they definitely refer to jQuery objects (and prevents you from prefixing with `$` if it definitely does not refer to a jQuery object).

2. `prefer-early-return` forces you to use an early return instead of nesting an entire function body in a conditional expression without an alternate.

Let me know if you want me to break this into two PRs, I figured I'd add them both at once but we can at list split it for ease of review.

cc/ @GoodForOneFare @bouk 