### PR TITLE
Use a range-generating function rather than CoffeeScript output

### DIFF
--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/both-variables.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/both-variables.input.js
@@ -1,0 +1,12 @@
+// [this.qux..foo.bar.baz()]
+
+(function() {
+  var ref;
+  var results = [];
+
+  for (var i = ref = this.qux, ref1 = foo.bar.baz(); (ref <= ref1 ? i <= ref1 : i >= ref1); (ref <= ref1 ? i++ : i--)) {
+      results.push(i);
+  }
+
+  return results;
+}).apply(this);

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/both-variables.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/both-variables.output.js
@@ -1,0 +1,7 @@
+// [this.qux..foo.bar.baz()]
+
+Shopify.range({
+  from: this.qux,
+  to: foo.bar.baz(),
+  inclusive: true
+});

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/end-variable.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/end-variable.input.js
@@ -1,0 +1,11 @@
+// [42..foo()]
+
+(function() {
+  var results = [];
+
+  for (var i = 42, ref = foo(); (42 <= ref ? i <= ref : i >= ref); (42 <= ref ? i++ : i--)) {
+    results.push(i);
+  }
+
+  return results;
+}).apply(this);

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/end-variable.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/end-variable.output.js
@@ -1,0 +1,7 @@
+// [42..foo()]
+
+Shopify.range({
+  from: 42,
+  to: foo(),
+  inclusive: true
+});

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/exclusive.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/exclusive.input.js
@@ -1,0 +1,12 @@
+// myRange = [11...400]
+
+var myRange = (function() {
+  var i;
+  var results = [];
+
+  for (i = 11; i < 400; i++) {
+      results.push(i);
+  }
+
+  return results;
+}).apply(this);

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/exclusive.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/exclusive.output.js
@@ -1,0 +1,7 @@
+// myRange = [11...400]
+
+var myRange = Shopify.range({
+  from: 11,
+  to: 400,
+  inclusive: false
+});

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/inclusive.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/inclusive.input.js
@@ -1,0 +1,12 @@
+// myRange = [11..400]
+
+var myRange = (function() {
+  var i;
+  var results = [];
+
+  for (i = 11; i <= 400; i++) {
+      results.push(i);
+  }
+
+  return results;
+}).apply(this);

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/inclusive.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/inclusive.output.js
@@ -1,0 +1,7 @@
+// myRange = [11..400]
+
+var myRange = Shopify.range({
+  from: 11,
+  to: 400,
+  inclusive: true
+});

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/similar-cases.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/similar-cases.input.js
@@ -1,0 +1,43 @@
+var myRange = (function() {
+  var i;
+  var results = [];
+
+  for (i = 11; i < 400; i++) {
+      results.push(i);
+  }
+
+  return results;
+}).foo(this);
+
+var myRange = (function() {
+  var i;
+  var results = [];
+
+  for (i = 11; i < 400; i++) {
+      results.push(i);
+  }
+
+  return results;
+})(this);
+
+var myRange = function() {
+  var i;
+  var results = [];
+
+  for (i = 11; i < 400; i++) {
+      results.push(i);
+  }
+
+  return results;
+};
+
+var myRange = (function() {
+  var i;
+  var results = [];
+
+  for (i = 11; i < 400; i++) {
+      results.push(i);
+  }
+
+  return somethingElse();
+}).apply(this);

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/similar-cases.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/similar-cases.output.js
@@ -1,0 +1,43 @@
+var myRange = (function() {
+  var i;
+  var results = [];
+
+  for (i = 11; i < 400; i++) {
+      results.push(i);
+  }
+
+  return results;
+}).foo(this);
+
+var myRange = (function() {
+  var i;
+  var results = [];
+
+  for (i = 11; i < 400; i++) {
+      results.push(i);
+  }
+
+  return results;
+})(this);
+
+var myRange = function() {
+  var i;
+  var results = [];
+
+  for (i = 11; i < 400; i++) {
+      results.push(i);
+  }
+
+  return results;
+};
+
+var myRange = (function() {
+  var i;
+  var results = [];
+
+  for (i = 11; i < 400; i++) {
+      results.push(i);
+  }
+
+  return somethingElse();
+}).apply(this);

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/start-variable.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/start-variable.input.js
@@ -1,0 +1,11 @@
+// callWith([foo...42])
+
+callWith((function() {
+  var results = [];
+
+  for (var i = foo; (foo <= 42 ? i < 42 : i > 42); (foo <= 42 ? i++ : i--)) {
+      results.push(i);
+  }
+
+  return results;
+}).apply(this));

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/start-variable.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/start-variable.output.js
@@ -1,0 +1,7 @@
+// callWith([foo...42])
+
+callWith(Shopify.range({
+  from: foo,
+  to: 42,
+  inclusive: false
+}));

--- a/packages/shopify-codemod/test/transforms/coffeescript-range-output-to-helper.test.js
+++ b/packages/shopify-codemod/test/transforms/coffeescript-range-output-to-helper.test.js
@@ -1,0 +1,28 @@
+import 'test-helper';
+import coffeescriptRangeOutputToHelper from 'coffeescript-range-output-to-helper';
+
+describe.only('coffeescriptRangeOutputToHelper', () => {
+  it('transforms inclusive ranges', () => {
+    expect(coffeescriptRangeOutputToHelper).to.transform('coffeescript-range-output-to-helper/inclusive');
+  });
+
+  it('transforms exclusive ranges', () => {
+    expect(coffeescriptRangeOutputToHelper).to.transform('coffeescript-range-output-to-helper/exclusive');
+  });
+
+  it('transforms ranges starting with variables', () => {
+    expect(coffeescriptRangeOutputToHelper).to.transform('coffeescript-range-output-to-helper/start-variable');
+  });
+
+  it('transforms ranges with end variables', () => {
+    expect(coffeescriptRangeOutputToHelper).to.transform('coffeescript-range-output-to-helper/end-variable');
+  });
+
+  it('transforms ranges with both variables', () => {
+    expect(coffeescriptRangeOutputToHelper).to.transform('coffeescript-range-output-to-helper/both-variables');
+  });
+
+  it('does not transform non-matching constructs', () => {
+    expect(coffeescriptRangeOutputToHelper).to.transform('coffeescript-range-output-to-helper/similar-cases');
+  });
+});

--- a/packages/shopify-codemod/transforms/coffeescript-range-output-to-helper.js
+++ b/packages/shopify-codemod/transforms/coffeescript-range-output-to-helper.js
@@ -1,0 +1,93 @@
+import {matchLast as matchLastNode} from './utils';
+
+const INCLUSIVE_OPERATORS = new Set(['<=', '>=']);
+
+export default function coffeescriptRangeOutputToHelper({source}, {jscodeshift: j}, {printOptions = {}}) {
+  const matchLast = matchLastNode.bind(null, j);
+
+  function looksLikeCoffeeScriptRangeFunctionExpression(path) {
+    const {i, results} = path.scope.getBindings();
+    return i != null && results != null;
+  }
+
+  return j(source)
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        property: {
+          type: 'Identifier',
+          name: 'apply',
+        },
+        object: {
+          type: 'FunctionExpression',
+          body: {
+            body: matchLast({
+              type: 'ReturnStatement',
+              argument: {
+                type: 'Identifier',
+                name: 'results',
+              },
+            }),
+          },
+        },
+      },
+    })
+    .filter((path) => looksLikeCoffeeScriptRangeFunctionExpression(path.get('callee', 'object'))
+    )
+    .replaceWith((path) => {
+      const forStatement = j(path)
+        .find(j.ForStatement)
+        .paths()[0];
+
+      let start;
+      let end;
+
+      const forStatementInit = forStatement.get('init');
+      const forStatementDeclarations = forStatementInit.get('declarations');
+      const initIsDeclaration = j.VariableDeclaration.check(forStatementInit.node);
+
+      const forStatementTest = forStatement.get('test');
+      const isComplexTest = j.ConditionalExpression.check(forStatementTest.node);
+
+      if (initIsDeclaration) {
+        const firstInitialization = forStatementDeclarations.get(0, 'init');
+
+        if (j.AssignmentExpression.check(firstInitialization.node)) {
+          start = firstInitialization.get('right');
+        } else {
+          start = firstInitialization;
+        }
+      } else {
+        start = forStatementInit.get('right');
+      }
+
+      if (initIsDeclaration && forStatementDeclarations.value.length > 1) {
+        end = forStatementDeclarations.get(1, 'init');
+      } else if (isComplexTest) {
+        end = forStatementTest.get('test', 'right');
+      } else {
+        end = forStatementTest.get('right');
+      }
+
+      const inclusive = INCLUSIVE_OPERATORS.has(
+        isComplexTest
+          ? forStatementTest.get('consequent', 'operator').value
+          : forStatementTest.get('operator').value
+      );
+
+      return j.callExpression(
+        j.memberExpression(
+          j.identifier('Shopify'),
+          j.identifier('range')
+        ),
+        [
+          j.objectExpression([
+            j.property('init', j.identifier('from'), start.value),
+            j.property('init', j.identifier('to'), end.value),
+            j.property('init', j.identifier('inclusive'), j.literal(inclusive)),
+          ]),
+        ],
+      );
+    })
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/remove-useless-return-from-test.js
+++ b/packages/shopify-codemod/transforms/remove-useless-return-from-test.js
@@ -1,9 +1,7 @@
-import {MOCHA_FUNCTIONS} from './utils';
+import {MOCHA_FUNCTIONS, matchLast as matchLastNode} from './utils';
 
 export default function removeUselessReturnFromTest({source}, {jscodeshift: j}, {printOptions = {}}) {
-  function matchLast(matcher) {
-    return (nodes) => nodes.length > 0 && j.match(nodes[nodes.length - 1], matcher);
-  }
+  const matchLast = matchLastNode.bind(null, j);
 
   return j(source)
     .find(j.CallExpression, {

--- a/packages/shopify-codemod/transforms/utils.js
+++ b/packages/shopify-codemod/transforms/utils.js
@@ -12,6 +12,10 @@ export function findLastMember(node) {
   return node;
 }
 
+export function matchLast(j, matcher) {
+  return (nodes) => nodes.length > 0 && j.match(nodes[nodes.length - 1], matcher);
+}
+
 export function insertAfterDirectives(body, newNode) {
   let i = 0;
   for (;i < body.length; i++) {


### PR DESCRIPTION
This PR adds a transform that changes all of the gross CoffeeScript-range-generated garbage into a reference to a global function. This transform will need to happen before the global reference to import one when run via edify. I couldn't think of a nice way to make this generic (so it could be used by non-Shopify code), but I figured that wasn't a big deal for now.

cc/ @GoodForOneFare 