### PR TITLE
Add useful plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,21 +23,21 @@
   "author": "Chris Sauve <chrismsauve@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "babel-cli": "^6.6.4",
-    "babel-core": "^6.7.0",
+    "babel-cli": "^6.7.5",
+    "babel-core": "^6.7.6",
     "babel-preset-shopify": "file:./packages/babel-preset-shopify",
     "chai": "^3.5.0",
     "coveralls": "^2.11.8",
+    "eslint": "^2.8.0",
     "eslint-plugin-shopify": "file:./packages/eslint-plugin-shopify",
-    "eslint": "^2.5.1",
     "isparta": "^4.0.0",
-    "istanbul": "^0.4.2",
+    "istanbul": "^0.4.3",
     "jscodeshift": "^0.3.17",
     "lerna": "^1.1.1",
     "mocha": "^2.4.5",
     "proxyquire": "^1.7.4",
     "shelljs": "^0.6.0",
-    "sinon-chai": "^2.8.0",
-    "sinon": "^1.17.3"
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/packages/chai-jscodeshift/package.json
+++ b/packages/chai-jscodeshift/package.json
@@ -4,9 +4,9 @@
   "description": "Chai assertion utilities for writing JSCodeShift Codemods.",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_PATH=$NODE_PATH:./test ../../node_modules/.bin/mocha 'test/**/*.test.js' --compilers js:babel-core/register",
+    "test": "../../node_modules/.bin/mocha 'test/**/*.test.js' --compilers js:babel-core/register",
     "test:watch": "npm run test -- --watch --reporter min",
-    "test:cover": "NODE_PATH=$NODE_PATH:./test ../../node_modules/.bin/babel-node ../../node_modules/.bin/isparta cover --reporter text --reporter html ../../node_modules/.bin/_mocha -- --reporter spec test/**/*.test.js",
+    "test:cover": "../../node_modules/.bin/babel-node ../../node_modules/.bin/isparta cover --reporter text --reporter html ../../node_modules/.bin/_mocha -- --reporter spec test/**/*.test.js",
     "clean": "rm -rf lib/",
     "build:lib": "../../node_modules/.bin/babel src --out-dir lib",
     "build": "npm run clean && npm run build:lib",
@@ -19,7 +19,10 @@
     "jscodeshift"
   ],
   "eslintConfig": {
-    "extends": "plugin:shopify/es5",
+    "extends": [
+      "plugin:shopify/es5",
+      "plugin:shopify/node"
+    ],
     "rules": {
       "no-sync": 0
     }

--- a/packages/chai-jscodeshift/test/.eslintrc.js
+++ b/packages/chai-jscodeshift/test/.eslintrc.js
@@ -1,10 +1,8 @@
 module.exports = {
-  extends: 'plugin:shopify/esnext',
-
-  env: {
-    mocha: true,
-    es6: true,
-  },
+  extends: [
+    'plugin:shopify/esnext',
+    'plugin:shopify/mocha',
+  ],
 
   globals: {
     expect: false,
@@ -13,7 +11,7 @@ module.exports = {
   },
 
   rules: {
-    'no-unused-expressions': 0,
-    'newline-per-chained-call': 0
+    'no-unused-expressions': 'off',
+    'newline-per-chained-call': 'off'
   },
 };

--- a/packages/chai-jscodeshift/test/index.test.js
+++ b/packages/chai-jscodeshift/test/index.test.js
@@ -1,4 +1,4 @@
-import 'test-helper';
+import './test-helper';
 
 import path from 'path';
 import chai from 'chai';

--- a/packages/eslint-plugin-shopify/README.md
+++ b/packages/eslint-plugin-shopify/README.md
@@ -72,10 +72,22 @@ This plugin also provides the following tool-specific configurations, which can 
 - [mocha](lib/config/mocha.js): Use this for projects that use [mocha](http://mochajs.org)/ [sinon](http://sinonjs.org)/ [chai](http://chaijs.com) for testing.
 - [ava](lib/config/ava.js): Use this for projects that use the [AVA test runner](https://github.com/sindresorhus/ava).
 - [flow](lib/config/flow.js): Use this for projects that use [flow](http://flowtype.org) for type checking.
+- [jquery](lib/config/jquery.js): Use this for projects that use [jQuery](http://jquery.com).
 
 ### node
 
 If you are working on a node module, we also provide the [node configuration](lib/config/esnext.js) for you. Note that this configuration needs to be used in conjunction with one of the core configurations (either `es5` or `esnext`). If you plan to transpile your code using Babel, use the `esnext` config. If you do not plan to do so, the config you choose depends on the version of node you wish to support, and how many ESNext features are natively available in that version. You can see a detailed list of what version of node supports what new JavaScript features by visiting http://node.green.
+
+A node project that will use Babel for transpilation would need the following ESLint config:
+
+```json
+{
+  "extends": [
+    "plugin:shopify/esnext",
+    "plugin:shopify/node"
+  ]
+}
+```
 
 ## Plugin-Provided Rules
 

--- a/packages/eslint-plugin-shopify/README.md
+++ b/packages/eslint-plugin-shopify/README.md
@@ -52,10 +52,13 @@ You can also add some "augmenting" configs on top of the "core" config by extend
 {
   "extends": [
     "plugin:shopify/esnext",
-    "plugin:shopify/lodash"
+    "plugin:shopify/lodash",
+    "plugin:shopify/mocha"
   ]
 }
 ```
+
+## Provided configurations
 
 This plugin provides the following core configurations:
 
@@ -65,7 +68,14 @@ This plugin provides the following core configurations:
 
 This plugin also provides the following tool-specific configurations, which can be used on top of the core configurations:
 
-- [lodash](lib/config/lodash.js): Use this for projects that use lodash.
+- [lodash](lib/config/lodash.js): Use this for projects that use [lodash](https://lodash.com).
+- [mocha](lib/config/mocha.js): Use this for projects that use [mocha](http://mochajs.org)/ [sinon](http://sinonjs.org)/ [chai](http://chaijs.com) for testing.
+- [ava](lib/config/ava.js): Use this for projects that use the [AVA test runner](https://github.com/sindresorhus/ava).
+- [flow](lib/config/flow.js): Use this for projects that use [flow](http://flowtype.org) for type checking.
+
+### node
+
+If you are working on a node module, we also provide the [node configuration](lib/config/esnext.js) for you. Note that this configuration needs to be used in conjunction with one of the core configurations (either `es5` or `esnext`). If you plan to transpile your code using Babel, use the `esnext` config. If you do not plan to do so, the config you choose depends on the version of node you wish to support, and how many ESNext features are natively available in that version. You can see a detailed list of what version of node supports what new JavaScript features by visiting http://node.green.
 
 ## Plugin-Provided Rules
 

--- a/packages/eslint-plugin-shopify/index.js
+++ b/packages/eslint-plugin-shopify/index.js
@@ -18,6 +18,7 @@ module.exports = {
     es5: require('./lib/config/es5'),
     esnext: require('./lib/config/esnext'),
     flow: require('./lib/config/flow'),
+    jquery: require('./lib/config/jquery'),
     lodash: require('./lib/config/lodash'),
     mocha: require('./lib/config/mocha'),
     node: require('./lib/config/node'),

--- a/packages/eslint-plugin-shopify/index.js
+++ b/packages/eslint-plugin-shopify/index.js
@@ -13,10 +13,14 @@ module.exports = {
   },
 
   configs: {
+    ava: require('./lib/config/ava'),
     core: require('./lib/config/core'),
     es5: require('./lib/config/es5'),
     esnext: require('./lib/config/esnext'),
-    react: require('./lib/config/react'),
+    flow: require('./lib/config/flow'),
     lodash: require('./lib/config/lodash'),
+    mocha: require('./lib/config/mocha'),
+    node: require('./lib/config/node'),
+    react: require('./lib/config/react'),
   },
 };

--- a/packages/eslint-plugin-shopify/lib/config/ava.js
+++ b/packages/eslint-plugin-shopify/lib/config/ava.js
@@ -1,0 +1,16 @@
+module.exports = {
+  env: {
+		es6: true,
+	},
+
+	parserOptions: {
+		ecmaVersion: 7,
+		sourceType: 'module',
+	},
+
+	plugins: [
+		'ava',
+	],
+
+  rules: require('./rules/ava'),
+};

--- a/packages/eslint-plugin-shopify/lib/config/ava.js
+++ b/packages/eslint-plugin-shopify/lib/config/ava.js
@@ -1,16 +1,16 @@
 module.exports = {
   env: {
-		es6: true,
-	},
+    es6: true,
+  },
 
-	parserOptions: {
-		ecmaVersion: 7,
-		sourceType: 'module',
-	},
+  parserOptions: {
+    ecmaVersion: 7,
+    sourceType: 'module',
+  },
 
-	plugins: [
-		'ava',
-	],
+  plugins: [
+    'ava',
+  ],
 
   rules: require('./rules/ava'),
 };

--- a/packages/eslint-plugin-shopify/lib/config/es5.js
+++ b/packages/eslint-plugin-shopify/lib/config/es5.js
@@ -1,9 +1,3 @@
 module.exports = {
   extends: 'plugin:shopify/core',
-
-  env: {
-    node: true,
-  },
-
-  rules: require('./rules/node'),
 };

--- a/packages/eslint-plugin-shopify/lib/config/esnext.js
+++ b/packages/eslint-plugin-shopify/lib/config/esnext.js
@@ -1,5 +1,4 @@
 var merge = require('merge');
-var coreConfig = require('./core');
 
 module.exports = {
   extends: 'plugin:shopify/core',

--- a/packages/eslint-plugin-shopify/lib/config/esnext.js
+++ b/packages/eslint-plugin-shopify/lib/config/esnext.js
@@ -7,25 +7,26 @@ module.exports = {
 
   env: {
     es6: true,
-    node: true,
+  },
+
+  parserOptions: {
+    ecmaVersion: 7,
+    sourceType: 'module',
   },
 
   plugins: [
     'babel',
-    'shopify',
+    'promise',
+    'sort-class-members',
+    'import',
   ],
-
-  parserOptions: merge.recursive(
-    coreConfig.parserOptions,
-    {
-      ecmaVersion: 7,
-      sourceType: 'module',
-    }
-  ),
 
   rules: merge(
     require('./rules/ecmascript-6'),
+    require('./rules/promise'),
     require('./rules/babel'),
+    require('./rules/sort-class-members'),
+    require('./rules/import'),
     {
       'no-param-reassign': 'off', // because of default params
       'shopify/prefer-class-properties': 'warn',

--- a/packages/eslint-plugin-shopify/lib/config/flow.js
+++ b/packages/eslint-plugin-shopify/lib/config/flow.js
@@ -1,0 +1,32 @@
+var merge = require('merge');
+
+module.exports = {
+  parser: 'babel-eslint',
+
+  env: {
+		es6: true,
+	},
+
+	parserOptions: {
+		ecmaVersion: 7,
+		sourceType: 'module',
+	},
+
+	plugins: [
+		'flowtype',
+    'shopify',
+	],
+
+  settings: {
+    flowtype: {
+      onlyFilesWithFlowAnnotation: true,
+    },
+  },
+
+  rules: merge(
+    require('./rules/flowtype'),
+    {
+      'shopify/require-flow': ['warn', 'explicit'],
+    }
+  ),
+};

--- a/packages/eslint-plugin-shopify/lib/config/flow.js
+++ b/packages/eslint-plugin-shopify/lib/config/flow.js
@@ -4,18 +4,18 @@ module.exports = {
   parser: 'babel-eslint',
 
   env: {
-		es6: true,
-	},
+    es6: true,
+  },
 
-	parserOptions: {
-		ecmaVersion: 7,
-		sourceType: 'module',
-	},
+  parserOptions: {
+    ecmaVersion: 7,
+    sourceType: 'module',
+  },
 
-	plugins: [
-		'flowtype',
+  plugins: [
+    'flowtype',
     'shopify',
-	],
+  ],
 
   settings: {
     flowtype: {

--- a/packages/eslint-plugin-shopify/lib/config/jquery.js
+++ b/packages/eslint-plugin-shopify/lib/config/jquery.js
@@ -1,0 +1,13 @@
+module.exports = {
+  env: {
+    jquery: true,
+  },
+
+  plugins: [
+    'shopify',
+  ],
+
+  rules: {
+    'shopify/jquery-dollar-sign-reference': 'warn',
+  },
+};

--- a/packages/eslint-plugin-shopify/lib/config/mocha.js
+++ b/packages/eslint-plugin-shopify/lib/config/mocha.js
@@ -1,0 +1,21 @@
+var merge = require('merge');
+
+module.exports = {
+  env: {
+    mocha: true,
+  },
+
+  plugins: [
+    'mocha',
+    'chai-expect',
+    'shopify',
+  ],
+
+  rules: merge(
+    require('./rules/mocha'),
+    require('./rules/chai-expect'),
+    {
+      'shopify/sinon-prefer-meaningful-assertions': 'warn',
+    }
+  ),
+};

--- a/packages/eslint-plugin-shopify/lib/config/node.js
+++ b/packages/eslint-plugin-shopify/lib/config/node.js
@@ -1,0 +1,7 @@
+module.exports = {
+  env: {
+    node: true,
+  },
+
+  rules: require('./rules/node'),
+};

--- a/packages/eslint-plugin-shopify/lib/config/node.js
+++ b/packages/eslint-plugin-shopify/lib/config/node.js
@@ -3,5 +3,9 @@ module.exports = {
     node: true,
   },
 
+  plugins: [
+    'node',
+  ],
+
   rules: require('./rules/node'),
 };

--- a/packages/eslint-plugin-shopify/lib/config/react.js
+++ b/packages/eslint-plugin-shopify/lib/config/react.js
@@ -1,21 +1,11 @@
 var merge = require('merge');
-var es6Config = require('./esnext');
 
 module.exports = {
   extends: 'plugin:shopify/esnext',
 
-  plugins: [
-    'babel',
-    'react',
-    'shopify',
-  ],
-
-  parserOptions: merge.recursive(
-    es6Config.parserOptions,
-    {
-      ecmaFeatures: {jsx: true},
-    }
-  ),
+  parserOptions: {
+    ecmaFeatures: {jsx: true},
+  },
 
   globals: {
     fetch: true,
@@ -23,5 +13,13 @@ module.exports = {
     ReactClass: true,
   },
 
-  rules: require('./rules/react'),
+  plugins: [
+    'react',
+    'jsx-a11y',
+  ],
+
+  rules: merge(
+    require('./rules/react'),
+    require('./rules/jsx-a11y')
+  ),
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/ava.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/ava.js
@@ -39,4 +39,4 @@ module.exports = {
   'ava/use-test': 'warn',
   // Ensure that t.true()/t.false() are used instead of t.truthy()/t.falsy().
   'ava/use-true-false': 'warn',
-}
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/ava.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/ava.js
@@ -1,0 +1,42 @@
+// see https://github.com/sindresorhus/eslint-plugin-ava
+
+module.exports = {
+  // Enforce or disallow assertion messages.
+  'ava/assertion-message': 'off',
+  // Limit the number of assertions in a test.
+  'ava/max-asserts': ['warn', 5],
+  // Ensure no test.cb() is used.
+  'ava/no-cb-test': 'warn',
+  // Ensure no tests have the same title.
+  'ava/no-identical-title': 'error',
+  // Ensure no tests are written in ignored files.
+  'ava/no-ignored-test-files': 'error',
+  // Ensure t.end() is only called inside test.cb().
+  'ava/no-invalid-end': 'error',
+  // Ensure no test.only() are present.
+  'ava/no-only-test': 'warn',
+  // Ensure no assertions are skipped.
+  'ava/no-skip-assert': 'error',
+  // Ensure no tests are skipped.
+  'ava/no-skip-test': 'error',
+  // Ensure t.end() is the last statement executed.
+  'ava/no-statement-after-end': 'error',
+  // Ensure no test.todo() is used.
+  'ava/no-todo-test': 'warn',
+  // Prevent the use of unknown test modifiers.
+  'ava/no-unknown-modifiers': 'error',
+  // Allow only use of the asserts that have no power-assert alternative.
+  'ava/prefer-power-assert': 'warn',
+  // Ensure callback tests are explicitly ended.
+  'ava/test-ended': 'error',
+  // Ensure tests have a title.
+  'ava/test-title': 'error',
+  // Prevent the incorrect use of t.
+  'ava/use-t-well': 'error',
+  // Ensure test functions use t as their parameter.
+  'ava/use-t': 'warn',
+  // Ensure that AVA is imported with test as the variable name.
+  'ava/use-test': 'warn',
+  // Ensure that t.true()/t.false() are used instead of t.truthy()/t.falsy().
+  'ava/use-true-false': 'warn',
+}

--- a/packages/eslint-plugin-shopify/lib/config/rules/ava.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/ava.js
@@ -26,7 +26,7 @@ module.exports = {
   // Prevent the use of unknown test modifiers.
   'ava/no-unknown-modifiers': 'error',
   // Allow only use of the asserts that have no power-assert alternative.
-  'ava/prefer-power-assert': 'warn',
+  'ava/prefer-power-assert': 'off',
   // Ensure callback tests are explicitly ended.
   'ava/test-ended': 'error',
   // Ensure tests have a title.

--- a/packages/eslint-plugin-shopify/lib/config/rules/chai-expect.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/chai-expect.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   // Prevent using comparisons in the expect() argument.
-  'chai-expect/no-iner-compare': 'warn',
+  'chai-expect/no-inner-compare': 'warn',
   // Prevent calling expect(...) without an assertion like .to.be.ok.
   'chai-expect/missing-assertion': 'error',
   // Prevent calling to.be.ok and other assertion properties as functions.

--- a/packages/eslint-plugin-shopify/lib/config/rules/chai-expect.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/chai-expect.js
@@ -1,0 +1,10 @@
+// see https://github.com/turbo87/eslint-plugin-chai-expect
+
+module.exports = {
+  // Prevent using comparisons in the expect() argument.
+  'chai-expect/no-iner-compare': 'warn',
+  // Prevent calling expect(...) without an assertion like .to.be.ok.
+  'chai-expect/missing-assertion': 'error',
+  // Prevent calling to.be.ok and other assertion properties as functions.
+  'chai-expect/terminating-properties': 'error',
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/ecmascript-6.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/ecmascript-6.js
@@ -32,7 +32,7 @@ module.exports = {
   // Require method and property shorthand syntax for object literals
   'object-shorthand': 'off',
   // Suggest using arrow functions as callbacks
-  'prefer-arrow-callback': 'error',
+  'prefer-arrow-callback': ['error', {allowNamedFunctions: true}],
   // Suggest using of const declaration for variables that are never modified after declared
   'prefer-const': 'warn',
   // Suggest using the rest parameters instead of arguments

--- a/packages/eslint-plugin-shopify/lib/config/rules/flowtype.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/flowtype.js
@@ -1,0 +1,14 @@
+// see https://github.com/gajus/eslint-plugin-flowtype
+
+module.exports = {
+  // Requires that all function parameters have type annotations.
+  'flowtype/require-parameter-type': 'warn',
+  // Requires that functions have return type annotation.
+  'flowtype/require-return-type': ['always', {annotateUndefined: 'never'}],
+  // Enforces consistent spacing after the type annotation colon.
+  'flowtype/space-after-type-colon': 'always',
+  // Enforces consistent spacing before the type annotation colon.
+  'flowtype/space-before-type-colon': 'never',
+  // Enforces a consistent naming pattern for type aliases.
+  'flowtype/type-id-match': ['warn', '^([A-Z][a-z0-9]+)+Type$'],
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/flowtype.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/flowtype.js
@@ -4,11 +4,11 @@ module.exports = {
   // Requires that all function parameters have type annotations.
   'flowtype/require-parameter-type': 'warn',
   // Requires that functions have return type annotation.
-  'flowtype/require-return-type': ['always', {annotateUndefined: 'never'}],
+  'flowtype/require-return-type': ['warn', 'always', {annotateUndefined: 'never'}],
   // Enforces consistent spacing after the type annotation colon.
-  'flowtype/space-after-type-colon': 'always',
+  'flowtype/space-after-type-colon': ['warn', 'always'],
   // Enforces consistent spacing before the type annotation colon.
-  'flowtype/space-before-type-colon': 'never',
+  'flowtype/space-before-type-colon': ['warn', 'never'],
   // Enforces a consistent naming pattern for type aliases.
   'flowtype/type-id-match': ['warn', '^([A-Z][a-z0-9]+)+Type$'],
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/import.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/import.js
@@ -1,0 +1,41 @@
+// see https://github.com/benmosher/eslint-plugin-import
+
+module.exports = {
+  // Static analysis
+
+  // Ensure imports point to a file/module that can be resolved.
+  'import/no-unresolved': 'error',
+  // Ensure named imports correspond to a named export in the remote file.
+  'import/named': 'error',
+  // Ensure a default export is present, given a default import.
+  'import/default': 'error',
+  // Ensure imported namespaces contain dereferenced properties as they are dereferenced.
+  'import/namespace': 'error',
+
+  // Helpful warnings
+
+  // Report any invalid exports, i.e. re-export of the same name
+  'import/export': 'error',
+  // Report use of exported name as identifier of default export
+  'import/no-named-as-default': 'warn',
+  // Report use of exported name as property of default export
+  'import/no-named-as-default-member': 'warn',
+  // Report imported names marked with @deprecated documentation tag
+  'import/no-deprecated': 'warn',
+
+  // Module systems
+
+  // Report CommonJS require calls and module.exports or exports.*.
+  'import/no-commonjs': 'off',
+  // Report AMD require and define calls.
+  'import/no-amd': 'off',
+
+  // Style guide
+
+  // Ensure all imports appear before other statements
+  'import/imports-first': 'warn',
+  // Report repeated import of the same module in multiple places
+  'import/no-duplicates': 'error',
+  // Report namespace imports
+  'import/no-namespace': 'off',
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/jsx-a11y.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/jsx-a11y.js
@@ -1,0 +1,34 @@
+// see https://github.com/evcohen/eslint-plugin-jsx-a11y
+
+module.exports = {
+  // Enforce tabIndex value is not greater than zero.
+  'jsx-a11y/avoid-positive-tabindex': 'error',
+  // Enforce that <img> JSX elements use the alt prop.
+  'jsx-a11y/img-uses-alt': 'error',
+  // Enforce that <label> elements have the htmlFor prop.
+  'jsx-a11y/label-uses-for': 'error',
+  // Enforce that onMouseOver/onMouseOut are accompanied by onFocus/onBlur for keyboard-only users.
+  'jsx-a11y/mouse-events-map-to-key-events': 'error',
+  // Enforce that the accessKey prop is not used on any element to avoid complications with keyboard commands used by a screenreader.
+  'jsx-a11y/no-access-key': 'error',
+  // Enforce an anchor element's href prop value is not just #.
+  'jsx-a11y/no-hash-href': 'error',
+  // Enforce all aria-* props are valid.
+  'jsx-a11y/no-invalid-aria': 'error',
+  // Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
+  'jsx-a11y/no-unsupported-elements-use-aria': 'error',
+  // Enforce that elements with onClick handlers must be focusable.
+  'jsx-a11y/onclick-has-focus': 'error',
+  // Enforce that non-interactive, visible elements (such as <div>) that have click handlers use the role attribute.
+  'jsx-a11y/onclick-uses-role': 'off',
+  // Enforce <img> alt prop does not contain the word "image", "picture", or "photo".
+  'jsx-a11y/redundant-alt': 'warn',
+  // Enforce that elements with ARIA roles must have all required attributes for that role.
+  'jsx-a11y/role-requires-aria': 'error',
+  // Enforce that onBlur is used instead of onChange.
+  'jsx-a11y/use-onblur-not-onchange': 'off',
+  // Enforce ARIA state and property values are valid.
+  'jsx-a11y/valid-aria-proptype': 'error',
+  // Enforce that elements with ARIA roles must use a valid, non-abstract ARIA role.
+  'jsx-a11y/valid-aria-role': 'error',
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/jsx-a11y.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/jsx-a11y.js
@@ -1,8 +1,6 @@
 // see https://github.com/evcohen/eslint-plugin-jsx-a11y
 
 module.exports = {
-  // Enforce tabIndex value is not greater than zero.
-  'jsx-a11y/avoid-positive-tabindex': 'error',
   // Enforce that <img> JSX elements use the alt prop.
   'jsx-a11y/img-uses-alt': 'error',
   // Enforce that <label> elements have the htmlFor prop.
@@ -13,22 +11,12 @@ module.exports = {
   'jsx-a11y/no-access-key': 'error',
   // Enforce an anchor element's href prop value is not just #.
   'jsx-a11y/no-hash-href': 'error',
-  // Enforce all aria-* props are valid.
-  'jsx-a11y/no-invalid-aria': 'error',
-  // Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
-  'jsx-a11y/no-unsupported-elements-use-aria': 'error',
-  // Enforce that elements with onClick handlers must be focusable.
-  'jsx-a11y/onclick-has-focus': 'error',
   // Enforce that non-interactive, visible elements (such as <div>) that have click handlers use the role attribute.
   'jsx-a11y/onclick-uses-role': 'off',
   // Enforce <img> alt prop does not contain the word "image", "picture", or "photo".
   'jsx-a11y/redundant-alt': 'warn',
-  // Enforce that elements with ARIA roles must have all required attributes for that role.
-  'jsx-a11y/role-requires-aria': 'error',
   // Enforce that onBlur is used instead of onChange.
   'jsx-a11y/use-onblur-not-onchange': 'off',
-  // Enforce ARIA state and property values are valid.
-  'jsx-a11y/valid-aria-proptype': 'error',
   // Enforce that elements with ARIA roles must use a valid, non-abstract ARIA role.
   'jsx-a11y/valid-aria-role': 'error',
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/mocha.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/mocha.js
@@ -4,7 +4,7 @@ module.exports = {
   // Disallow exclusive mocha tests.
   'mocha/no-exclusive-tests': 'warn',
   // Disallow skipped mocha tests.
-  'mocha/no-skipped-tests': 'warn',
+  'mocha/no-skipped-tests': 'error',
   // Disallow pending/unimplemented mocha tests.
   'mocha/no-pending-tests': 'warn',
   // Enforces handling of callbacks for async tests.

--- a/packages/eslint-plugin-shopify/lib/config/rules/mocha.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/mocha.js
@@ -1,0 +1,16 @@
+// see https://github.com/lo1tuma/eslint-plugin-mocha
+
+module.exports = {
+  // Disallow exclusive mocha tests.
+  'mocha/no-exclusive-tests': 'warn',
+  // Disallow skipped mocha tests.
+  'mocha/no-skipped-tests': 'warn',
+  // Disallow pending/unimplemented mocha tests.
+  'mocha/no-pending-tests': 'warn',
+  // Enforces handling of callbacks for async tests.
+  'mocha/handle-done-callback': 'warn',
+  // Disallow synchronous tests.
+  'mocha/no-synchronous-tests': 'off',
+  // Disallow global tests.
+  'mocha/no-global-tests': 'error',
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/node.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/node.js
@@ -1,4 +1,4 @@
-// see http://eslint.org/docs/rules/#nodejs
+// see http://eslint.org/docs/rules/#nodejs and https://github.com/mysticatea/eslint-plugin-node
 
 module.exports = {
   // enforce return after a callback
@@ -21,4 +21,17 @@ module.exports = {
   'no-restricted-modules': 'off',
   // Disallow use of synchronous methods
   'no-sync': 'warn',
+
+  // Disallow import and export declarations for files that don't exist.
+  'node/no-missing-import': 'off',
+  // Disallow require()s for files that don't exist.
+  'node/no-missing-require': 'error',
+  // Disallow import and export declarations for files that are not published.
+  'node/no-unpublished-import': 'off',
+  // Disallow require()s for files that are not published.
+  'node/no-unpublished-require': 'error',
+  // Disallow unsupported ECMAScript features on the specified version.
+  'node/no-unsupported-features': 'off',
+  // Suggest correct usage of shebang.
+  'node/shebang': 'error',
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/promise.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/promise.js
@@ -1,0 +1,10 @@
+// see https://github.com/xjamundx/eslint-plugin-promise
+
+module.exports = {
+  // Ensure that each time a then() is applied to a promise, a catch() is applied as well. Exceptions are made if you are returning that promise.
+  'promise/catch-or-return': 'warn',
+  // Ensure that inside a then() you make sure to return a new promise or value.
+  'promise/always-return': 'error',
+  // Enforce standard parameter names for Promise constructors.
+  'promise/param-names': 'warn',
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/react.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/react.js
@@ -11,6 +11,8 @@ module.exports = {
   'react/jsx-curly-spacing': ['warn', 'never', {allowMultiline: true}],
   // Enforce or disallow spaces around equal signs in JSX attributes
   'react/jsx-equals-spacing': ['warn', 'never'],
+  // Enforce position of the first prop in JSX
+  'react/jsx-first-prop-new-line': 'off',
   // Validate props indentation in JSX
   'react/jsx-indent-props': ['warn', 2],
   // Validate JSX indentation
@@ -18,7 +20,7 @@ module.exports = {
   // Validate JSX has key prop when in array or iterator
   'react/jsx-key': 'error',
   // Limit maximum of props on a single line in JSX
-  'react/jsx-max-props-per-line': 'off',
+  'react/jsx-max-props-per-line': ['warn', 'multiline'],
   // Prevent usage of .bind() and arrow functions in JSX props
   'react/jsx-no-bind': 'off',
   // Prevent duplicate props in JSX
@@ -67,6 +69,8 @@ module.exports = {
   'react/react-in-jsx-scope': 'error',
   // Restrict file extensions that may be required
   'react/require-extension': ['error', {extensions: ['.js']}],
+  // Enforce ES5 or ES6 class for returning value in render function
+  'react/require-render-return': 'error',
   // Prevent extra closing tags for components without children
   'react/self-closing-comp': 'warn',
   // Enforce component methods order

--- a/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/shopify.js
@@ -4,7 +4,7 @@ module.exports = {
   // Requires (or disallows) semicolons for class properties.
   'shopify/class-property-semi': 'warn',
   // Requires that all jQuery objects are assigned to references prefixed with `$`.
-  'shopify/jquery-dollar-sign-reference': 'warn',
+  'shopify/jquery-dollar-sign-reference': 'off',
   // Prevents the usage of unnecessary computed properties.
   'shopify/no-useless-computed-properties': 'error',
   // Prefer class properties to assignment of literals in constructors.

--- a/packages/eslint-plugin-shopify/lib/config/rules/sort-class-members.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/sort-class-members.js
@@ -1,0 +1,26 @@
+// see https://github.com/bryanrsmith/eslint-plugin-sort-class-members
+
+module.exports = {
+  'sort-class-members/sort-class-members': [
+    'warn',
+    {
+      order: [
+        '[static-members]',
+        '[properties]',
+        '[conventional-private-properties]',
+        'constructor',
+        '[public-instance-members]',
+        '[conventional-private-methods]',
+        '[everything-else]',
+      ],
+      groups: {
+        'static-members': [{static: true}],
+        'public-instance-members': [{
+          static: false,
+          name: '/[^_].+/',
+        }],
+      },
+      accessorPairPositioning: 'getThenSet',
+    },
+  ]
+}

--- a/packages/eslint-plugin-shopify/lib/config/rules/sort-class-members.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/sort-class-members.js
@@ -22,5 +22,5 @@ module.exports = {
       },
       accessorPairPositioning: 'getThenSet',
     },
-  ]
-}
+  ],
+};

--- a/packages/eslint-plugin-shopify/lib/config/rules/stylistic-issues.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/stylistic-issues.js
@@ -29,7 +29,7 @@ module.exports = {
   'id-length': ['warn', {
     min: 2,
     properties: 'always',
-    exceptions: ['x', 'y', 'i', 'j', '_', '$'],
+    exceptions: ['x', 'y', 'i', 'j', 't', '_', '$'],
   }],
   // Require identifiers to match the provided regular expression
   'id-match': 'off',

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -29,9 +29,10 @@
   },
   "dependencies": {
     "babel-eslint": "^6.0.0",
-    "eslint-plugin-react": "^4.2.3",
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-lodash": "^1.6.5",
+    "eslint-plugin-react": "^4.2.3",
+    "eslint-plugin-sort-class-members": "^1.0.1",
     "merge": "^1.2.0"
   }
 }

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -29,10 +29,14 @@
   },
   "dependencies": {
     "babel-eslint": "^6.0.0",
+    "eslint-plugin-ava": "^2.2.1",
     "eslint-plugin-babel": "^3.1.0",
+    "eslint-plugin-flowtype": "^2.2.6",
     "eslint-plugin-import": "^1.5.0",
+    "eslint-plugin-jsx-a11y": "^0.6.2",
     "eslint-plugin-lodash": "^1.6.5",
     "eslint-plugin-mocha": "^2.2.0",
+    "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-react": "^4.2.3",
     "eslint-plugin-sort-class-members": "^1.0.1",
     "merge": "^1.2.0"

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "peerDependencies": {
-    "eslint": ">=2.5.1"
+    "eslint": ">=2.8.0"
   },
   "dependencies": {
     "babel-eslint": "^6.0.0",
@@ -38,11 +38,11 @@
     "eslint-plugin-flowtype": "^2.2.6",
     "eslint-plugin-import": "^1.5.0",
     "eslint-plugin-jsx-a11y": "^0.6.2",
-    "eslint-plugin-lodash": "^1.6.5",
+    "eslint-plugin-lodash": "^1.6.9",
     "eslint-plugin-mocha": "^2.2.0",
     "eslint-plugin-node": "^1.0.0",
     "eslint-plugin-promise": "^1.1.0",
-    "eslint-plugin-react": "^4.2.3",
+    "eslint-plugin-react": "^5.0.1",
     "eslint-plugin-sort-class-members": "^1.0.1",
     "merge": "^1.2.0"
   }

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -22,7 +22,10 @@
   "homepage": "https://github.com/Shopify/javascript/tree/master/packages/eslint-plugin-shopify",
   "repository": "https://github.com/Shopify/javascript/tree/master/packages/eslint-plugin-shopify",
   "eslintConfig": {
-    "extends": "plugin:shopify/es5"
+    "extends": [
+      "plugin:shopify/es5",
+      "plugin:shopify/node"
+    ]
   },
   "peerDependencies": {
     "eslint": ">=2.5.1"
@@ -31,11 +34,13 @@
     "babel-eslint": "^6.0.0",
     "eslint-plugin-ava": "^2.2.1",
     "eslint-plugin-babel": "^3.1.0",
+    "eslint-plugin-chai-expect": "^1.1.1",
     "eslint-plugin-flowtype": "^2.2.6",
     "eslint-plugin-import": "^1.5.0",
     "eslint-plugin-jsx-a11y": "^0.6.2",
     "eslint-plugin-lodash": "^1.6.5",
     "eslint-plugin-mocha": "^2.2.0",
+    "eslint-plugin-node": "^1.0.0",
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-react": "^4.2.3",
     "eslint-plugin-sort-class-members": "^1.0.1",

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "babel-eslint": "^6.0.0",
     "eslint-plugin-babel": "^3.1.0",
+    "eslint-plugin-import": "^1.5.0",
     "eslint-plugin-lodash": "^1.6.5",
     "eslint-plugin-mocha": "^2.2.0",
     "eslint-plugin-react": "^4.2.3",

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -31,6 +31,7 @@
     "babel-eslint": "^6.0.0",
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-lodash": "^1.6.5",
+    "eslint-plugin-mocha": "^2.2.0",
     "eslint-plugin-react": "^4.2.3",
     "eslint-plugin-sort-class-members": "^1.0.1",
     "merge": "^1.2.0"

--- a/packages/generator-eslint-shopify/package.json
+++ b/packages/generator-eslint-shopify/package.json
@@ -35,13 +35,13 @@
     ]
   },
   "dependencies": {
-    "chalk": "^1.1.1",
+    "chalk": "^1.1.3",
     "generator-eslint-config": "^2.0.0",
     "yeoman-generator": "^0.22.2",
-    "yosay": "^1.1.0"
+    "yosay": "^1.1.1"
   },
   "devDependencies": {
-    "yeoman-assert": "^2.1.1",
+    "yeoman-assert": "^2.2.0",
     "yeoman-test": "^1.1.0"
   }
 }

--- a/packages/generator-eslint-shopify/package.json
+++ b/packages/generator-eslint-shopify/package.json
@@ -29,14 +29,10 @@
   "homepage": "https://github.com/Shopify/javascript/tree/master/packages/generator-eslint-shopify",
   "repository": "https://github.com/Shopify/javascript/tree/master/packages/generator-eslint-shopify",
   "eslintConfig": {
-    "extends": "plugin:shopify/esnext",
-    "env": {
-      "es6": true,
-      "node": true
-    },
-    "rules": {
-      "shopify/require-flow": 0
-    }
+    "extends": [
+      "plugin:shopify/esnext",
+      "plugin:shopify/node"
+    ]
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/packages/shopify-codemod/package.json
+++ b/packages/shopify-codemod/package.json
@@ -19,7 +19,10 @@
     ]
   },
   "eslintConfig": {
-    "extends": "plugin:shopify/esnext"
+    "extends": [
+      "plugin:shopify/esnext",
+      "plugin:shopify/node"
+    ]
   },
   "author": {
     "name": "Chris Sauve",

--- a/packages/shopify-codemod/test/.eslintrc.js
+++ b/packages/shopify-codemod/test/.eslintrc.js
@@ -1,14 +1,12 @@
 module.exports = {
-  env: {
-    mocha: true,
-    es6: true,
-  },
+  extends: 'plugin:shopify/mocha',
 
   globals: {
     expect: false,
   },
 
   rules: {
-    'no-unused-expressions': 0,
+    'no-unused-expressions': 'off',
+    'import/no-unresolved': 'off',
   },
 };

--- a/packages/shopify-codemod/test/transforms/coffeescript-range-output-to-helper.test.js
+++ b/packages/shopify-codemod/test/transforms/coffeescript-range-output-to-helper.test.js
@@ -1,7 +1,7 @@
 import 'test-helper';
 import coffeescriptRangeOutputToHelper from 'coffeescript-range-output-to-helper';
 
-describe.only('coffeescriptRangeOutputToHelper', () => {
+describe('coffeescriptRangeOutputToHelper', () => {
   it('transforms inclusive ranges', () => {
     expect(coffeescriptRangeOutputToHelper).to.transform('coffeescript-range-output-to-helper/inclusive');
   });

--- a/packages/shopify-codemod/transforms/global-reference-to-import.js
+++ b/packages/shopify-codemod/transforms/global-reference-to-import.js
@@ -117,7 +117,8 @@ export default function globalReferenceToImport(
           }
         });
 
-      for (const {file, name} of imports.values()) {
+      for (const anImport of imports.values()) {
+        const {file, name} = anImport;
         const {node: {body}} = path;
         insertAfterDirectives(
           body,

--- a/react/README.md
+++ b/react/README.md
@@ -146,6 +146,29 @@ This guide provides a few guidelines on writing sensible React. Many of these ru
   <Good status="is great!" />
   ```
 
+- [2.5](#2.5) <a name="2.5"></a> When props span over multiple lines, list one prop per line (with no props on the same line as the opening tag).
+
+  ESLint rule: [`jsx-first-prop-new-line`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md)
+
+  ```js
+  // bad
+  <Bad status="is not very good"
+    redeemable={false}
+  />
+
+  <Bad
+    status="is not very good" redeemable={false}
+  />
+
+  // good
+  <Good status="is great!" needsWork={false} />
+
+  <Good
+    status="is great!"
+    needsWork={false}
+  />
+  ```
+
 [↑ scrollTo('#table-of-contents')](#table-of-contents)
 
 


### PR DESCRIPTION
Closes #38. This PR adds a bunch of plugins that address tools/ features of JS that we use at Shopify. It also adds specific configurations for tools that can be used to augment the "core" configurations (es5/ esnext/ react). These include:

- Plugin/ config for mocha/ chai/ sinon.
- Plugin/ config for Ava
- Plugin/ config for flow

I also cleaned up how the core configurations were structured. This includes removing the `node` env from all core configs, and moving it into a new, dedicated config that can be used in conjunction with the core ones. Also updated all documentation and projects to work correctly with the new configs. This actually caught an exclusive test we were doing in `shopify-codemod`, so it's already paying dividends!

I don't think the rule selections are particularly controversial, but let me know if there's anything you think is a bad choice.

cc/ @GoodForOneFare 
