### PR TITLE
Make esify an installable binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ coverage
 .DS_STORE
 npm-debug.log
 
-# generator-eslint-shopify
 packages/generator-eslint-shopify/generators

--- a/packages/esify/README.md
+++ b/packages/esify/README.md
@@ -1,0 +1,17 @@
+# esify
+
+`esify` is a combination of various tools with the purpose of automatically translating Shopify’s CoffeeScript to ESNext. Unless you work at Shopify, you probably don’t need this.
+
+## Installation
+
+```sh
+npm install -g esify
+```
+
+## Usage
+
+From the root of the Shopify directory, run this script with a single, relative CoffeeScript file, or a glob pattern. Wait for it to finish, and marvel at the clean ESNext code that is spit out beside the original file! Note this script does not delete the original CoffeeScript file — you should review the output before pushing any changes.
+
+```sh
+esify app/assets/javascripts/admin/lib/*.coffee
+```

--- a/packages/esify/bin/esify
+++ b/packages/esify/bin/esify
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var glob = require('glob');
+var path = require('path');
+var transform = require('..');
+
+if (!/shopify/i.test(path.basename(process.cwd()))) {
+  throw new Error('You must run this command from the root of the Shopify repo.');
+}
+
+var pattern = process.argv[2];
+var files = getFiles(pattern);
+var errors = {};
+
+if (files.length === 0) {
+  throw new Error('No .coffee files found for "' + process.argv[2] + '".');
+}
+
+files.forEach(handleFile);
+
+var errorKeys = Object.keys(errors);
+
+if (errorKeys.length > 0) {
+  console.log();
+  console.log('Errors:');
+
+  errorKeys.forEach(function(error) {
+    console.log('\t' + error);
+
+    errors[error].forEach(function(filePath) {
+      console.log('\t\t' + filePath);
+    });
+  });
+}
+
+function getFiles(filePattern) {
+  if (filePattern == null) {
+    throw new Error('Pass in a .coffee file, or glob pattern.');
+  }
+
+  return glob
+    .sync(filePattern, {ignore: ['node_modules/**', 'vendor/**']})
+    .filter(function(filePath) { return filePath.match(/\.coffee$/); });
+}
+
+function handleFile(filePath) {
+  var source = fs.readFileSync(filePath, {encoding: 'utf8'});
+  try {
+    var transformed = transform(source, {testTransforms: filePath.indexOf('test') >= 0});
+    writeJavaScriptFile(filePath, transformed);
+  } catch (error) {
+    handleTransformError(filePath, error);
+  }
+}
+
+function handleTransformError(filePath, error) {
+  var errorType;
+  var errorLocation;
+  var errorInfo = error.message.match(/^(.+) (\(.+?\))$/);
+
+  if (errorInfo) {
+    errorType = errorInfo[1];
+    errorLocation = errorInfo[2];
+  } else {
+    errorType = error.message;
+    errorLocation = '';
+  }
+
+  errors[errorType] = errors[errorType] || [];
+  errors[errorType].push(filePath + ' ' + errorLocation);
+
+  console.error(filePath);
+  console.error(error.stack);
+}
+
+function writeJavaScriptFile(filePath, transformed) {
+  var newFile = path.join(
+    path.dirname(filePath),
+    path.basename(filePath, '.coffee').replace(/_/g, '-') + '.js'
+  );
+
+  fs.writeFileSync(newFile, transformed);
+  console.log(filePath + ' => ' + newFile);
+}

--- a/packages/esify/index.js
+++ b/packages/esify/index.js
@@ -1,0 +1,63 @@
+var path = require('path');
+var decaf = require('shopify-decaf');
+var jscodeshift = require('jscodeshift');
+
+require('babel-register')({ignore: false});
+
+var TRANSFORMS = [
+  {path: 'js-codemod/transforms/arrow-function'},
+  {path: 'js-codemod/transforms/template-literals'},
+  {path: 'js-codemod/transforms/object-shorthand'},
+  {path: 'js-codemod/transforms/no-vars'},
+  {path: 'js-codemod/transforms/unquote-properties'},
+  {path: 'shopify-codemod/transforms/constant-function-expression-to-statement'},
+  {path: 'shopify-codemod/transforms/ternary-statement-to-if-statement'},
+  {path: 'shopify-codemod/transforms/mocha-context-to-closure', test: true},
+  {path: 'shopify-codemod/transforms/mocha-context-to-global-reference', test: true},
+  {path: 'shopify-codemod/transforms/coffeescript-range-output-to-helper'},
+  {path: 'shopify-codemod/transforms/remove-useless-return-from-test', test: true},
+  {path: 'shopify-codemod/transforms/conditional-assign-to-if-statement'},
+  {path: 'shopify-codemod/transforms/function-to-arrow'},
+  {path: 'shopify-codemod/transforms/global-assignment-to-default-export', test: false},
+  {path: 'shopify-codemod/transforms/global-reference-to-import'},
+];
+
+var OPTIONS = {
+  appGlobalIdentifiers: ['Shopify', 'Sello'],
+  javascriptSourceLocation: path.join(process.cwd(), 'app/assets/javascripts'),
+  printOptions: {
+    quote: 'single',
+    trailingComma: true,
+    tabWidth: 2,
+    wrapColumn: 1000,
+  },
+  testContextToGlobals: {
+    testClock: {
+      properties: ['clock'],
+      replace: true,
+    },
+    sandbox: {
+      properties: ['spy', 'stub', 'mock', 'server', 'requests'],
+    },
+  },
+};
+
+function runTransform(code, name) {
+  var module = require(name);
+  if (module.__esModule) { module = module.default; }
+
+  var newCode = module({path: null, source: code}, {jscodeshift: jscodeshift}, OPTIONS);
+  return newCode == null ? code : newCode;
+}
+
+module.exports = function transform(source, options) {
+  var testTransforms = options.testTransforms == null ? false : options.testTransforms;
+  var code = decaf.compile(source, OPTIONS.printOptions);
+
+  TRANSFORMS.forEach(function(transformer) {
+    if (transformer.test == null || transformer.test === testTransforms) {
+      code = runTransform(code, transformer.path);
+    }
+  });
+  return code;
+};

--- a/packages/esify/package.json
+++ b/packages/esify/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "esify",
+  "main": "index.js",
+  "version": "10.11.2",
+  "author": "Bouke van der Bijl <bouke@shopify.com>",
+  "description": "A CLI for converting Shopify’s CoffeeScript to ESNext.",
+  "eslintConfig": {
+    "extends": [
+      "plugin:shopify/es5",
+      "plugin:shopify/node"
+    ],
+    "rules": {
+      "no-console": "off",
+      "no-sync": "off"
+    }
+  },
+  "bin": "./bin/esify",
+  "dependencies": {
+    "glob": "7.0.3",
+    "shopify-decaf": "latest",
+    "js-codemod": "cpojer/js-codemod",
+    "jscodeshift": "0.3.15",
+    "babel-register": "^6.7.2",
+    "shopify-codemod": "latest"
+  }
+}

--- a/packages/shopify-codemod/package.json
+++ b/packages/shopify-codemod/package.json
@@ -1,12 +1,11 @@
 {
   "name": "shopify-codemod",
-  "version": "10.11.0",
+  "version": "10.11.1",
   "description": "Custom JSCodeShift transforms to help convert our rusty JavaScript.",
   "homepage": "https://github.com/Shopify/javascript/tree/master/packages/shopify-codemod",
   "repository": "https://github.com/Shopify/javascript/tree/master/packages/shopify-codemod",
-  "main": "transforms/index.js",
   "scripts": {
-    "test": "NODE_PATH=./transforms:./test:$NODE_PATH ../../node_modules/.bin/mocha 'test/**/*.test.js' --compilers js:babel-core/register",
+    "test": "NODE_PATH=$NODE_PATH:./transforms:./test ../../node_modules/.bin/mocha 'test/**/*.test.js' --compilers js:babel-core/register",
     "test:watch": "npm run test -- --watch --reporter min",
     "test:cover": "NODE_PATH=$NODE_PATH:./transforms:./test ../../node_modules/.bin/babel-node ../../node_modules/.bin/isparta cover --root transforms/ --reporter text --reporter html ../../node_modules/.bin/_mocha -- --reporter spec test/**/*.test.js"
   },


### PR DESCRIPTION
This adds `esify` as an actual project into the JS repo, and moves things around so that it can work by being installed globally and running `esify path/to/file.coffee` from the root of the Shopify repo.

cc/ @GoodForOneFare @bouk 