### PR TITLE
Add no-fully-static-classes rule

### DIFF
--- a/packages/eslint-plugin-shopify/docs/rules/no-fully-static-classes.md
+++ b/packages/eslint-plugin-shopify/docs/rules/no-fully-static-classes.md
@@ -1,0 +1,44 @@
+# Prevents the declaration of classes consisting only of static members. (no-fully-static-classes)
+
+## Rule Details
+
+This rule recommends using object literals instead of defining classes consisting only of static members. Fully-static classes are functionally no different from object literals, other than that they can (pointlessly) be instantiated with the `new` keyword.
+
+The following patterns are considered warnings:
+
+```js
+class Foo {
+  static foo = true;
+}
+
+class Bar {
+  static foo = false;
+  static bar() {};
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+class Foo {
+  foo = true;
+  static bar() {}
+}
+
+class Bar {
+  static foo = true;
+  bar() {}
+  baz() {}
+}
+
+class Baz {}
+
+class Qux extends Buzz {
+  static foo = true;
+  static bar() {}
+}
+```
+
+## When Not To Use It
+
+If you do not wish to enforce prevent declarations of fully-static classes, you can safely disable this rule.

--- a/packages/eslint-plugin-shopify/lib/rules/no-fully-static-classes.js
+++ b/packages/eslint-plugin-shopify/lib/rules/no-fully-static-classes.js
@@ -8,7 +8,7 @@ module.exports = function(context) {
     if (node.superClass == null && members.length && members.every(isStaticMember)) {
       context.report({
         node: node,
-        message: 'Classes declaring only static members should be objects instead.',
+        message: 'Classes declaring only static members should be objects or named exports instead.',
       });
     }
   }

--- a/packages/eslint-plugin-shopify/lib/rules/no-fully-static-classes.js
+++ b/packages/eslint-plugin-shopify/lib/rules/no-fully-static-classes.js
@@ -1,0 +1,20 @@
+module.exports = function(context) {
+  function isStaticMember(node) {
+    return (node.type === 'MethodDefinition' || node.type === 'ClassProperty') && node.static;
+  }
+
+  function checkClass(node) {
+    var members = node.body.body;
+    if (node.superClass == null && members.length && members.every(isStaticMember)) {
+      context.report({
+        node: node,
+        message: 'Classes declaring only static members should be objects instead.',
+      });
+    }
+  }
+
+  return {
+    ClassDeclaration: checkClass,
+    ClassExpression: checkClass,
+  };
+};

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -11,9 +11,9 @@
   ],
   "author": "Chris Sauve <chris.sauve@shopify.com>",
   "scripts": {
-    "test": "../../node_modules/.bin/mocha tests/ --recursive --reporter spec",
+    "test": "../../node_modules/.bin/mocha tests/ --recursive --reporter spec --compilers js:babel-core/register",
     "test:watch": "npm test -- --watch --reporter min",
-    "test:cover": "../../node_modules/.bin/istanbul cover --dir coverage ../../node_modules/.bin/_mocha -- --recursive tests/"
+    "test:cover": "../../node_modules/.bin/istanbul cover --dir coverage ../../node_modules/.bin/_mocha -- --compilers js:babel-core/register --recursive tests/"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/eslint-plugin-shopify/tests/lib/rules/no-fully-static-classes.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/no-fully-static-classes.js
@@ -14,7 +14,7 @@ function staticProperty(name = 'qux') { return `static ${name} = true;`; }
 function errorWithType(type) {
   return [{
     type,
-    message: 'Classes declaring only static members should be objects instead.',
+    message: 'Classes declaring only static members should be objects or named exports instead.',
   }];
 }
 

--- a/packages/eslint-plugin-shopify/tests/lib/rules/no-fully-static-classes.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/no-fully-static-classes.js
@@ -1,0 +1,183 @@
+const rule = require('../../../lib/rules/no-fully-static-classes');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+require('babel-eslint');
+
+const parser = 'babel-eslint';
+
+function method(name = 'foo') { return `${name}() {}`; }
+function staticMethod(name = 'bar') { return `static ${name}() {}`; }
+function property(name = 'baz') { return `${name} = true;`; }
+function staticProperty(name = 'qux') { return `static ${name} = true;`; }
+
+function errorWithType(type) {
+  return [{
+    type,
+    message: 'Classes declaring only static members should be objects instead.',
+  }];
+}
+
+ruleTester.run('prefer-class-properties', rule, {
+  valid: [
+    {
+      code: `class Foo {
+        ${method('foo')}
+        ${method('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `class Foo {
+        ${staticMethod('foo')}
+        ${method('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `class Foo {
+        ${property('foo')}
+        ${property('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `class Foo {
+        ${property('foo')}
+        ${staticProperty('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `class Foo {
+        ${method('foo')}
+        ${property('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `class Foo {
+        ${method('foo')}
+        ${staticProperty('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `class Foo {
+        ${staticMethod('foo')}
+        ${property('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `const Foo = class {
+        ${method('foo')}
+        ${method('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `const Foo = class {
+        ${staticMethod('foo')}
+        ${method('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `const Foo = class {
+        ${property('foo')}
+        ${property('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `const Foo = class {
+        ${property('foo')}
+        ${staticProperty('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `const Foo = class {
+        ${method('foo')}
+        ${property('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `const Foo = class {
+        ${method('foo')}
+        ${staticProperty('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: `const Foo = class {
+        ${staticMethod('foo')}
+        ${property('bar')}
+      }`,
+      parser,
+    },
+    {
+      code: 'class Foo {}',
+      parser,
+    },
+    {
+      code: `class Foo extends Bar {
+        ${staticMethod('foo')}
+        ${staticProperty('bar')}
+      }`,
+      parser,
+    },
+  ],
+  invalid: [
+    {
+      code: `class Foo {
+        ${staticMethod('foo')}
+        ${staticMethod('bar')}
+      }`,
+      parser,
+      errors: errorWithType('ClassDeclaration'),
+    },
+    {
+      code: `class Foo {
+        ${staticProperty('foo')}
+        ${staticProperty('bar')}
+      }`,
+      parser,
+      errors: errorWithType('ClassDeclaration'),
+    },
+    {
+      code: `class Foo {
+        ${staticProperty('foo')}
+        ${staticMethod('bar')}
+      }`,
+      parser,
+      errors: errorWithType('ClassDeclaration'),
+    },
+    {
+      code: `const Foo = class {
+        ${staticMethod('foo')}
+        ${staticMethod('bar')}
+      }`,
+      parser,
+      errors: errorWithType('ClassExpression'),
+    },
+    {
+      code: `const Foo = class {
+        ${staticProperty('foo')}
+        ${staticProperty('bar')}
+      }`,
+      parser,
+      errors: errorWithType('ClassExpression'),
+    },
+    {
+      code: `const Foo = class {
+        ${staticProperty('foo')}
+        ${staticMethod('bar')}
+      }`,
+      parser,
+      errors: errorWithType('ClassExpression'),
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds a rule to prevent the use of classes with only static members. I see this a bunch, particularly from people that aren't really used to JavaScript, and it drives me completely crazy (obviously, an object literal would be better since it avoids the one level of extra object creation).

cc/ @GoodForOneFare @bouk 