### PR TITLE
Fix: CoffeeScript range now works without defined i

### DIFF
--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/loop.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/loop.input.js
@@ -1,0 +1,13 @@
+// doSomething() for i in [1...300]
+
+for (let i of (function() {
+    var results = [];
+
+    for (i = 1; i < 300; i++) {
+        results.push(i);
+    }
+
+    return results;
+}).apply(this)) {
+  doSomething();
+}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/loop.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/loop.output.js
@@ -1,0 +1,9 @@
+// doSomething() for i in [1...300]
+
+for (let i of Shopify.range({
+  from: 1,
+  to: 300,
+  inclusive: false
+})) {
+  doSomething();
+}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/similar-cases.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/similar-cases.input.js
@@ -41,3 +41,15 @@ var myRange = (function() {
 
   return somethingElse();
 }).apply(this);
+
+for (let i of (function() {
+    var results = [];
+
+    for (i = 1; i < 300; i++) {
+      results.doSomething(i);
+    }
+
+    return results;
+}).apply(this)) {
+  doSomething();
+}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/similar-cases.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-range-output-to-helper/similar-cases.output.js
@@ -41,3 +41,15 @@ var myRange = (function() {
 
   return somethingElse();
 }).apply(this);
+
+for (let i of (function() {
+    var results = [];
+
+    for (i = 1; i < 300; i++) {
+      results.doSomething(i);
+    }
+
+    return results;
+}).apply(this)) {
+  doSomething();
+}


### PR DESCRIPTION
I was using a pretty shitty heuristic to figure out functions that looked like the output of CoffeeScript ranges before (specifically, the `loop.input.js` file was not converting before). This PR uses a better set of criteria in order to make that decision.

cc/ @GoodForOneFare 