### PR TITLE
Strip unnecessary parenthesis from template strings

### DIFF
--- a/packages/esify/index.js
+++ b/packages/esify/index.js
@@ -17,6 +17,7 @@ var TRANSFORMS = [
   {path: 'shopify-codemod/transforms/global-reference-to-import'},
   {path: 'js-codemod/transforms/arrow-function'},
   {path: 'js-codemod/transforms/template-literals'},
+  {path: 'shopify-codemod/transforms/strip-template-literal-parenthesis'},
   {path: 'js-codemod/transforms/object-shorthand'},
   {path: 'js-codemod/transforms/no-vars'},
   {path: 'js-codemod/transforms/unquote-properties'},

--- a/packages/shopify-codemod/test/fixtures/strip-template-literal-parenthesis/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/strip-template-literal-parenthesis/basic.input.js
@@ -1,0 +1,24 @@
+(`test`);
+
+const foo = (`foo${bar}`);
+
+const bar = document.querySelector((`.${className}`));
+
+$((`#${id}`)).addClass('foo');
+
+
+function f1() {
+  return (`abc${this.message()}def`);
+}
+
+const foobar = new URI({
+  path: (`/${endpoint}`)
+});
+
+foo[(`bar`)] = (`foobar`);
+
+if ((`foo`) === 'foo') {
+
+}
+
+if ((foo === bar) && (baz === qux)) {}

--- a/packages/shopify-codemod/test/fixtures/strip-template-literal-parenthesis/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/strip-template-literal-parenthesis/basic.output.js
@@ -1,0 +1,24 @@
+`test`;
+
+const foo = `foo${bar}`;
+
+const bar = document.querySelector(`.${className}`);
+
+$(`#${id}`).addClass('foo');
+
+
+function f1() {
+  return `abc${this.message()}def`;
+}
+
+const foobar = new URI({
+  path: `/${endpoint}`
+});
+
+foo[`bar`] = `foobar`;
+
+if (`foo` === 'foo') {
+
+}
+
+if ((foo === bar) && (baz === qux)) {}

--- a/packages/shopify-codemod/test/transforms/strip-template-literal-parenthesis.test.js
+++ b/packages/shopify-codemod/test/transforms/strip-template-literal-parenthesis.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import stripTemplateLiteralParenthesis from 'strip-template-literal-parenthesis';
+
+describe('stripTemplateLiteralParenthesis', () => {
+  it('removes unnecessary parenthesis from template literals', () => {
+    expect(stripTemplateLiteralParenthesis).to.transform('strip-template-literal-parenthesis/basic');
+  });
+});

--- a/packages/shopify-codemod/transforms/strip-template-literal-parenthesis.js
+++ b/packages/shopify-codemod/transforms/strip-template-literal-parenthesis.js
@@ -1,0 +1,13 @@
+function forceReprint({node}) {
+  // Inspired by https://github.com/cpojer/js-codemod/blob/b627c7faaacbe3cbe48050aea70ebc9aa4684c9b/transforms/trailing-commas.js#L25-L27
+  node.original = null;
+}
+
+export default function stripTemplateLiteralParenthesis({source}, {jscodeshift: j}, {printOptions = {}}) {
+  return j(source)
+    .find(j.TemplateLiteral)
+    .map((path) => path.parentPath)
+    // The jscode-shift AST doesn't capture parenthesis info; forcing a reprint will render the template string sans parens.
+    .forEach(forceReprint)
+    .toSource(printOptions);
+}


### PR DESCRIPTION
Decaf wraps *every* template string with parenthesis.  There's nowhere in the Shopify codebase that requires this.

This transform relies on odd behaviour to strip out parenthesis; I'm guessing that recast sees a new property on the node and this forces a (good) destructive change.  There's an unsupported `Node#parenthesizedExpression` property that *may* make this less haphazard, but I couldn't get it to work any more effectively than this solution.

/cc @lemonmade 