### PR TITLE
Add CoffeeScript soak transform

### DIFF
--- a/packages/esify/index.js
+++ b/packages/esify/index.js
@@ -5,12 +5,15 @@ var jscodeshift = require('jscodeshift');
 require('babel-register')({ignore: false});
 
 var TRANSFORMS = [
+  {path: 'shopify-codemod/transforms/coffeescript-soak-to-condition'},
   {path: 'shopify-codemod/transforms/constant-function-expression-to-statement'},
   {path: 'shopify-codemod/transforms/ternary-statement-to-if-statement'},
   {path: 'shopify-codemod/transforms/mocha-context-to-closure', test: true},
   {path: 'shopify-codemod/transforms/mocha-context-to-global-reference', test: true},
   {path: 'shopify-codemod/transforms/coffeescript-range-output-to-helper'},
   {path: 'shopify-codemod/transforms/remove-useless-return-from-test', test: true},
+  {path: 'shopify-codemod/transforms/remove-addeventlistener-returns'},
+  {path: 'shopify-codemod/transforms/remove-empty-returns'},
   {path: 'shopify-codemod/transforms/conditional-assign-to-if-statement'},
   {path: 'shopify-codemod/transforms/function-to-arrow'},
   {path: 'shopify-codemod/transforms/global-assignment-to-default-export', test: false},

--- a/packages/shopify-codemod/README.md
+++ b/packages/shopify-codemod/README.md
@@ -12,6 +12,40 @@ This repository contains a collection of Codemods written with [JSCodeshift](htt
 
 ## Included Transforms
 
+### `coffeescript-soak-to-condition`
+
+Changes the output of CoffeeScript’s soak operations (`foo?.bar.baz?()`) into a cleaner, more idiomatic JavaScript expression appropriate for its location in code.
+
+```sh
+jscodeshift -t shopify-codemod/transforms/coffeescript-soak-to-condition <file>
+```
+
+#### Example
+
+```js
+// foo = bar?.baz?()
+var foo = typeof bar !== 'undefined' && bar !== null ? (typeof bar.baz === 'function' ? bar.baz() : void 0) : void 0;
+
+// BECOMES
+
+if (bar != null && typeof bar.baz === 'function') {
+  var foo = bar.baz();
+}
+
+// if a?[bar]?()
+if (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) {
+
+}
+
+// BECOMES
+
+// if a?[bar]?()
+// else if a?[bar]?()
+if (a != null && typeof a[bar] === 'function' && a[bar]()) {
+
+}
+```
+
 ### `coffeescript-range-output-to-helper`
 
 Changes the output of CoffeeScript’s range operator (`[foo...bar]`) into a reference to Shopify’s global range helper. Because this creates a global, you should run the `global-reference-to-import` transform after this one.

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.input.js
@@ -8,3 +8,8 @@ for (let bar of bars) {
 
 // (foo = bar?.baz) ->
 function aFunc(foo = typeof bar !== "undefined" && bar !== null ? bar.baz : void 0) {}
+
+// if foo = baz?.qux
+if(foo = (bar = typeof baz !== "undefined" && baz !== null ? baz.qux : void 0)) {
+
+}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.input.js
@@ -1,15 +1,10 @@
-// foo; foo = bar?()?.baz.qux?.buzz
-foo = typeof bar === "function" ? ((ref = bar()) != null ? ((ref1 = ref.baz.qux) != null ? ref1.buzz : void 0) : void 0) : void 0;
+// foo; foo = bar.baz?()
+foo = typeof bar.baz === "function" ? bar.baz() : void 0;
 
-// foo += bar?()?.baz.qux?.buzz || some.default() for bar in bars
+// foo += bar.baz?() || some.default() for bar in bars
 for (let bar of bars) {
-  foo += ((typeof bar === "function" ? (ref = bar()) != null ? ((ref1 = ref.baz.qux) != null ? ref1.buzz : void 0) : void 0 : void 0)) || some.default();
+  foo += (typeof bar.baz === "function" ? bar.baz() : void 0) || some.default();
 }
 
 // (foo = bar?.baz) ->
 function aFunc(foo = typeof bar !== "undefined" && bar !== null ? bar.baz : void 0) {}
-
-// foo = bar?()?.baz.qux?.buzz
-// bar = foo.something()
-var foo = typeof bar === "function" ? ((ref = bar()) != null ? ((ref1 = ref.baz.qux) != null ? ref1.buzz : void 0) : void 0) : void 0,
-  bar = foo.somethingElse();

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.input.js
@@ -8,3 +8,8 @@ for (let bar of bars) {
 
 // (foo = bar?.baz) ->
 function aFunc(foo = typeof bar !== "undefined" && bar !== null ? bar.baz : void 0) {}
+
+// foo = bar?()?.baz.qux?.buzz
+// bar = foo.something()
+var foo = typeof bar === "function" ? ((ref = bar()) != null ? ((ref1 = ref.baz.qux) != null ? ref1.buzz : void 0) : void 0) : void 0,
+  bar = foo.somethingElse();

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.input.js
@@ -1,0 +1,10 @@
+// foo; foo = bar?()?.baz.qux?.buzz
+foo = typeof bar === "function" ? ((ref = bar()) != null ? ((ref1 = ref.baz.qux) != null ? ref1.buzz : void 0) : void 0) : void 0;
+
+// foo += bar?()?.baz.qux?.buzz || some.default() for bar in bars
+for (let bar of bars) {
+  foo += ((typeof bar === "function" ? (ref = bar()) != null ? ((ref1 = ref.baz.qux) != null ? ref1.buzz : void 0) : void 0 : void 0)) || some.default();
+}
+
+// (foo = bar?.baz) ->
+function aFunc(foo = typeof bar !== "undefined" && bar !== null ? bar.baz : void 0) {}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.output.js
@@ -1,6 +1,5 @@
-if (typeof bar.baz === 'function') {
-  foo = bar.baz();
-}
+// foo; foo = bar.baz?()
+foo = (typeof bar.baz === 'function' ? bar.baz() : undefined);
 
 // foo += bar.baz?() || some.default() for bar in bars
 for (let bar of bars) {
@@ -9,3 +8,8 @@ for (let bar of bars) {
 
 // (foo = bar?.baz) ->
 function aFunc(foo = (bar != null ? bar.baz : undefined)) {}
+
+// if foo = baz?.qux
+if(foo = (bar = (baz != null ? baz.qux : undefined))) {
+
+}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.output.js
@@ -1,16 +1,11 @@
-if (typeof bar === 'function' && bar() != null && bar().baz.qux != null) {
-  foo = bar().baz.qux.buzz;
+if (typeof bar.baz === 'function') {
+  foo = bar.baz();
 }
 
-// foo += bar?()?.baz.qux?.buzz || some.default() for bar in bars
+// foo += bar.baz?() || some.default() for bar in bars
 for (let bar of bars) {
-  foo += ((((typeof bar === 'function' && bar() != null && bar().baz.qux != null ? bar().baz.qux.buzz : undefined)))) || some.default();
+  foo += (((typeof bar.baz === 'function' ? bar.baz() : undefined))) || some.default();
 }
 
 // (foo = bar?.baz) ->
 function aFunc(foo = (bar != null ? bar.baz : undefined)) {}
-
-// foo = bar?()?.baz.qux?.buzz
-// bar = foo.something()
-var foo = (typeof bar === 'function' && bar() != null && bar().baz.qux != null ? bar().baz.qux.buzz : undefined),
-  bar = foo.somethingElse();

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.output.js
@@ -1,0 +1,11 @@
+if (typeof bar === 'function' && bar() != null && bar().baz.qux != null) {
+  foo = bar().baz.qux.buzz;
+}
+
+// foo += bar?()?.baz.qux?.buzz || some.default() for bar in bars
+for (let bar of bars) {
+  foo += ((((typeof bar === 'function' && bar() != null && bar().baz.qux != null ? bar().baz.qux.buzz : undefined)))) || some.default();
+}
+
+// (foo = bar?.baz) ->
+function aFunc(foo = (bar != null ? bar.baz : undefined)) {}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/assignment.output.js
@@ -9,3 +9,8 @@ for (let bar of bars) {
 
 // (foo = bar?.baz) ->
 function aFunc(foo = (bar != null ? bar.baz : undefined)) {}
+
+// foo = bar?()?.baz.qux?.buzz
+// bar = foo.something()
+var foo = (typeof bar === 'function' && bar() != null && bar().baz.qux != null ? bar().baz.qux.buzz : undefined),
+  bar = foo.somethingElse();

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/basic.input.js
@@ -9,3 +9,5 @@ var foo = (ref = bar.baz) != null ? ((ref1 = ref.qux) != null ? ref1.buzz : void
 
 // foo = bar?[baz]?[qux].buzz?.fuzz
 var foo = typeof bar !== "undefined" && bar !== null ? ((ref = bar[baz]) != null ? ((ref1 = ref[qux].buzz) != null ? ref1.fuzz : void 0) : void 0) : void 0;
+
+var foo = bar != null ? bar.baz() : void 0;

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/basic.input.js
@@ -1,0 +1,11 @@
+// foo = bar?.baz
+var foo = typeof bar !== "undefined" && bar !== null ? bar.baz : void 0;
+
+// foo = bar?.baz.qux?.buzz
+var foo = typeof bar !== "undefined" && bar !== null ? ((ref = bar.baz.qux) != null ? ref.buzz : void 0) : void 0;
+
+// foo = bar.baz?.qux?.buzz
+var foo = (ref = bar.baz) != null ? ((ref1 = ref.qux) != null ? ref1.buzz : void 0) : void 0;
+
+// foo = bar?[baz]?[qux].buzz?.fuzz
+var foo = typeof bar !== "undefined" && bar !== null ? ((ref = bar[baz]) != null ? ((ref1 = ref[qux].buzz) != null ? ref1.fuzz : void 0) : void 0) : void 0;

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/basic.output.js
@@ -13,3 +13,7 @@ if (bar.baz != null && bar.baz.qux != null) {
 if (bar != null && bar[baz] != null && bar[baz][qux].buzz != null) {
   var foo = bar[baz][qux].buzz.fuzz;
 }
+
+if (bar != null) {
+  var foo = bar.baz();
+}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/basic.output.js
@@ -1,0 +1,15 @@
+if (bar != null) {
+  var foo = bar.baz;
+}
+
+if (bar != null && bar.baz.qux != null) {
+  var foo = bar.baz.qux.buzz;
+}
+
+if (bar.baz != null && bar.baz.qux != null) {
+  var foo = bar.baz.qux.buzz;
+}
+
+if (bar != null && bar[baz] != null && bar[baz][qux].buzz != null) {
+  var foo = bar[baz][qux].buzz.fuzz;
+}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/function-calls.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/function-calls.input.js
@@ -1,0 +1,11 @@
+// foo = bar.baz?()
+var foo = typeof bar.baz === "function" ? bar.baz() : void 0;
+
+// foo = bar?()?.baz.qux?.buzz
+var foo = typeof bar === "function" ? ((ref = bar()) != null ? ((ref1 = ref.baz.qux) != null ? ref1.buzz : void 0) : void 0) : void 0;
+
+// bar.baz?()
+typeof bar.baz === "function" ? bar.baz() : void 0;
+
+// foo = bar[baz]?()
+var foo = typeof bar[baz] === "function" ? bar[baz]() : void 0;

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/function-calls.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/function-calls.output.js
@@ -2,9 +2,8 @@ if (typeof bar.baz === 'function') {
   var foo = bar.baz();
 }
 
-if (typeof bar === 'function' && bar() != null && bar().baz.qux != null) {
-  var foo = bar().baz.qux.buzz;
-}
+// foo = bar?()?.baz.qux?.buzz
+var foo = typeof bar === "function" ? ((ref = bar()) != null ? ((ref1 = ref.baz.qux) != null ? ref1.buzz : void 0) : void 0) : void 0;
 
 if (typeof bar.baz === 'function') {
   bar.baz();

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/function-calls.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/function-calls.output.js
@@ -1,0 +1,15 @@
+if (typeof bar.baz === 'function') {
+  var foo = bar.baz();
+}
+
+if (typeof bar === 'function' && bar() != null && bar().baz.qux != null) {
+  var foo = bar().baz.qux.buzz;
+}
+
+if (typeof bar.baz === 'function') {
+  bar.baz();
+}
+
+if (typeof bar[baz] === 'function') {
+  var foo = bar[baz]();
+}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/logical-expressions.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/logical-expressions.input.js
@@ -1,0 +1,55 @@
+// if a?[bar]?() == 'baz'
+if ((typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) === 'baz') {
+
+}
+
+// foo = a?[bar]?() == 'baz'
+var foo = (typeof a !== "undefined" && a !== null ? typeof a[bar] === "function" ? a[bar]() : void 0 : void 0) === 'baz';
+
+// if a?[bar]?() == undefined
+if ((typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) === undefined) {
+
+}
+
+// var foo = a?[bar]?() != undefined
+var foo = (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) !== undefined;
+
+// var foo = a?[bar]?() == null
+var foo = (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) == null;
+
+// if 'baz' == a?[bar]?()
+if ('baz' === (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0)) {
+
+}
+
+// foo = 'baz' == a?[bar]?()
+var foo = 'baz' === (typeof a !== "undefined" && a !== null ? typeof a[bar] === "function" ? a[bar]() : void 0 : void 0);
+
+// if undefined == a?[bar]?()
+if (undefined === (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0)) {
+
+}
+
+// var foo = undefined != a?[bar]?()
+var foo = undefined !== (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0);
+
+// var foo = null == a?[bar]?()
+var foo = null == (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0);
+
+// var foo = baz == a?[bar]?()
+var foo = baz === (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0);
+
+// var foo = baz.qux == a?[bar]?()
+var foo = baz.qux === (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0);
+
+// var foo = baz.qux() == a?[bar]?()
+var foo = baz.qux() === (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0);
+
+// var foo = a?[bar]?() == {baz: qux}
+var foo = (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) === {baz: qux};
+
+// var foo = a?[bar]?() == [baz, qux]
+var foo = (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) === [baz, qux];
+
+// var foo = a?[bar]?() == new Baz()
+var foo = (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) === new Baz();

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/logical-expressions.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/logical-expressions.output.js
@@ -1,0 +1,55 @@
+// if a?[bar]?() == 'baz'
+if (a != null && typeof a[bar] === 'function' && a[bar]() === 'baz') {
+
+}
+
+// foo = a?[bar]?() == 'baz'
+var foo = a != null && typeof a[bar] === 'function' && a[bar]() === 'baz';
+
+// if a?[bar]?() == undefined
+if (a == null || typeof a[bar] !== 'function' || a[bar]() === undefined) {
+
+}
+
+// var foo = a?[bar]?() != undefined
+var foo = a != null && typeof a[bar] === 'function' && a[bar]() !== undefined;
+
+// var foo = a?[bar]?() == null
+var foo = a == null || typeof a[bar] !== 'function' || a[bar]() == null;
+
+// if 'baz' == a?[bar]?()
+if (a != null && typeof a[bar] === 'function' && 'baz' === a[bar]()) {
+
+}
+
+// foo = 'baz' == a?[bar]?()
+var foo = a != null && typeof a[bar] === 'function' && 'baz' === a[bar]();
+
+// if undefined == a?[bar]?()
+if (a == null || typeof a[bar] !== 'function' || undefined === a[bar]()) {
+
+}
+
+// var foo = undefined != a?[bar]?()
+var foo = a != null && typeof a[bar] === 'function' && undefined !== a[bar]();
+
+// var foo = null == a?[bar]?()
+var foo = a == null || typeof a[bar] !== 'function' || null == a[bar]();
+
+// var foo = baz == a?[bar]?()
+var foo = baz === (((a != null && typeof a[bar] === 'function' ? a[bar]() : undefined)));
+
+// var foo = baz.qux == a?[bar]?()
+var foo = baz.qux === (((a != null && typeof a[bar] === 'function' ? a[bar]() : undefined)));
+
+// var foo = baz.qux() == a?[bar]?()
+var foo = baz.qux() === (((a != null && typeof a[bar] === 'function' ? a[bar]() : undefined)));
+
+// var foo = a?[bar]?() == {baz: qux}
+var foo = a != null && typeof a[bar] === 'function' && a[bar]() === {baz: qux};
+
+// var foo = a?[bar]?() == [baz, qux]
+var foo = a != null && typeof a[bar] === 'function' && a[bar]() === [baz, qux];
+
+// var foo = a?[bar]?() == new Baz()
+var foo = a != null && typeof a[bar] === 'function' && a[bar]() === new Baz();

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
@@ -19,6 +19,25 @@ if (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[b
 
 }
 
+// if a?[bar]?() == 'baz'
+if ((typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) === 'baz') {
+
+}
+
+// foo = a?[bar]?() == 'baz'
+var foo = (typeof a !== "undefined" && a !== null ? typeof a[bar] === "function" ? a[bar]() : void 0 : void 0) === 'baz';
+
+// if a?[bar]?() == undefined
+if ((typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) === undefined) {
+
+}
+
+// var foo = a?[bar]?() != undefined
+var foo = (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) !== undefined;
+
+// var foo = a?[bar]?() == null
+var foo = (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) == null
+
 // while a?[bar]?()
 while (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) {
 

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
@@ -1,0 +1,29 @@
+// a?[bar]?()?
+((typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0)) != null;
+
+// foo = -> a?[bar]?()
+function foo() {
+	return typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0;
+}
+
+// foo = bar: a?[bar]?()
+var foo = {
+  bar: typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0,
+}
+
+// if a?[bar]?()
+// else if a?[bar]?()
+if (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) {
+
+} else if (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) {
+
+}
+
+// while a?[bar]?()
+while (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) {
+
+}
+
+do {
+
+} while (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0);

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
@@ -19,25 +19,6 @@ if (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[b
 
 }
 
-// if a?[bar]?() == 'baz'
-if ((typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) === 'baz') {
-
-}
-
-// foo = a?[bar]?() == 'baz'
-var foo = (typeof a !== "undefined" && a !== null ? typeof a[bar] === "function" ? a[bar]() : void 0 : void 0) === 'baz';
-
-// if a?[bar]?() == undefined
-if ((typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) === undefined) {
-
-}
-
-// var foo = a?[bar]?() != undefined
-var foo = (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) !== undefined;
-
-// var foo = a?[bar]?() == null
-var foo = (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) == null
-
 // while a?[bar]?()
 while (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) {
 

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
@@ -27,3 +27,13 @@ while (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? 
 do {
 
 } while (typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0);
+
+// unless a?[bar]?()
+if (!(typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0)) {
+
+}
+
+// foo = bar: !a?[bar]?()
+var foo = {
+  bar: !(typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0),
+}

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
@@ -23,6 +23,25 @@ if (a != null && typeof a[bar] === 'function' && a[bar]()) {
 
 }
 
+// if a?[bar]?() == 'baz'
+if (a != null && typeof a[bar] === 'function' && a[bar]() === 'baz') {
+
+}
+
+// foo = a?[bar]?() == 'baz'
+var foo = a != null && typeof a[bar] === 'function' && a[bar]() === 'baz';
+
+// if a?[bar]?() == undefined
+if ((((a != null && typeof a[bar] === 'function' ? a[bar]() : undefined))) === undefined) {
+
+}
+
+// var foo = a?[bar]?() != undefined
+var foo = a != null && typeof a[bar] === 'function' && a[bar]() !== undefined;
+
+// var foo = a?[bar]?() == null
+var foo = (((a != null && typeof a[bar] === 'function' ? a[bar]() : undefined))) == null
+
 // while a?[bar]?()
 while (a != null && typeof a[bar] === 'function' && a[bar]()) {
 

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
@@ -1,0 +1,33 @@
+// a?[bar]?()?
+a != null && typeof a[bar] === 'function' && a[bar]() != null;
+
+// foo = -> a?[bar]?()
+function foo() {
+  if (a != null && typeof a[bar] === 'function') {
+    return a[bar]();
+  } else {
+    return null;
+  }
+}
+
+// foo = bar: a?[bar]?()
+var foo = {
+  bar: (a != null && typeof a[bar] === 'function' ? a[bar]() : undefined),
+}
+
+// if a?[bar]?()
+// else if a?[bar]?()
+if (a != null && typeof a[bar] === 'function' && a[bar]()) {
+
+} else if (a != null && typeof a[bar] === 'function' && a[bar]()) {
+
+}
+
+// while a?[bar]?()
+while (a != null && typeof a[bar] === 'function' && a[bar]()) {
+
+}
+
+do {
+
+} while (a != null && typeof a[bar] === 'function' && a[bar]());

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
@@ -23,25 +23,6 @@ if (a != null && typeof a[bar] === 'function' && a[bar]()) {
 
 }
 
-// if a?[bar]?() == 'baz'
-if (a != null && typeof a[bar] === 'function' && a[bar]() === 'baz') {
-
-}
-
-// foo = a?[bar]?() == 'baz'
-var foo = a != null && typeof a[bar] === 'function' && a[bar]() === 'baz';
-
-// if a?[bar]?() == undefined
-if ((((a != null && typeof a[bar] === 'function' ? a[bar]() : undefined))) === undefined) {
-
-}
-
-// var foo = a?[bar]?() != undefined
-var foo = a != null && typeof a[bar] === 'function' && a[bar]() !== undefined;
-
-// var foo = a?[bar]?() == null
-var foo = (((a != null && typeof a[bar] === 'function' ? a[bar]() : undefined))) == null
-
 // while a?[bar]?()
 while (a != null && typeof a[bar] === 'function' && a[bar]()) {
 

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
@@ -31,3 +31,13 @@ while (a != null && typeof a[bar] === 'function' && a[bar]()) {
 do {
 
 } while (a != null && typeof a[bar] === 'function' && a[bar]());
+
+// unless a?[bar]?()
+if (a == null || typeof a[bar] !== 'function' || !a[bar]()) {
+
+}
+
+// foo = bar: !a?[bar]?()
+var foo = {
+  bar: a == null || typeof a[bar] !== 'function' || !a[bar](),
+}

--- a/packages/shopify-codemod/test/transforms/coffeescript-soak-to-condition.test.js
+++ b/packages/shopify-codemod/test/transforms/coffeescript-soak-to-condition.test.js
@@ -1,0 +1,20 @@
+import 'test-helper';
+import coffeescriptSoakToCondition from 'coffeescript-soak-to-condition';
+
+describe('coffeescriptSoakToCondition', () => {
+  it('transforms the basic case', () => {
+    expect(coffeescriptSoakToCondition).to.transform('coffeescript-soak-to-condition/basic');
+  });
+
+  it('transforms soaked function calls', () => {
+    expect(coffeescriptSoakToCondition).to.transform('coffeescript-soak-to-condition/function-calls');
+  });
+
+  it('transforms assignment expressions', () => {
+    expect(coffeescriptSoakToCondition).to.transform('coffeescript-soak-to-condition/assignment');
+  });
+
+  it('handles different parent paths', () => {
+    expect(coffeescriptSoakToCondition).to.transform('coffeescript-soak-to-condition/other-parents');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/coffeescript-soak-to-condition.test.js
+++ b/packages/shopify-codemod/test/transforms/coffeescript-soak-to-condition.test.js
@@ -1,7 +1,7 @@
 import 'test-helper';
 import coffeescriptSoakToCondition from 'coffeescript-soak-to-condition';
 
-describe.only('coffeescriptSoakToCondition', () => {
+describe('coffeescriptSoakToCondition', () => {
   it('transforms the basic case', () => {
     expect(coffeescriptSoakToCondition).to.transform('coffeescript-soak-to-condition/basic');
   });

--- a/packages/shopify-codemod/test/transforms/coffeescript-soak-to-condition.test.js
+++ b/packages/shopify-codemod/test/transforms/coffeescript-soak-to-condition.test.js
@@ -1,7 +1,7 @@
 import 'test-helper';
 import coffeescriptSoakToCondition from 'coffeescript-soak-to-condition';
 
-describe('coffeescriptSoakToCondition', () => {
+describe.only('coffeescriptSoakToCondition', () => {
   it('transforms the basic case', () => {
     expect(coffeescriptSoakToCondition).to.transform('coffeescript-soak-to-condition/basic');
   });
@@ -12,6 +12,10 @@ describe('coffeescriptSoakToCondition', () => {
 
   it('transforms assignment expressions', () => {
     expect(coffeescriptSoakToCondition).to.transform('coffeescript-soak-to-condition/assignment');
+  });
+
+  it('transforms logical expressions', () => {
+    expect(coffeescriptSoakToCondition).to.transform('coffeescript-soak-to-condition/logical-expressions');
   });
 
   it('handles different parent paths', () => {

--- a/packages/shopify-codemod/transforms/coffeescript-soak-to-condition.js
+++ b/packages/shopify-codemod/transforms/coffeescript-soak-to-condition.js
@@ -74,6 +74,10 @@ export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, 
           newBinaryExpression
         )
       );
+    } else if (j.UnaryExpression.check(parentNode) && parentNode.operator === '!') {
+      parentPath.replace(
+        j.logicalExpression('||', invertCondition(condition), j.unaryExpression('!', finalValue))
+      );
     } else {
       path.replace(
         j.conditionalExpression(condition, finalValue, j.identifier('undefined'))

--- a/packages/shopify-codemod/transforms/coffeescript-soak-to-condition.js
+++ b/packages/shopify-codemod/transforms/coffeescript-soak-to-condition.js
@@ -8,6 +8,7 @@ export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, 
       const currentTest = currentConsequent.get('test');
       const newMembers = getBaseExpressionFromTest(currentTest);
       memberExpression = augmentMemberExpression(memberExpression, newMembers);
+      if (hasCallExpression(memberExpression)) { return; }
 
       const newCondition = isFunctionCheck(currentTest.value)
         ? j.binaryExpression('===', j.unaryExpression('typeof', memberExpression), j.literal('function'))
@@ -130,6 +131,23 @@ export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, 
     } else {
       return getBaseExpressionFromFunctionTest(path);
     }
+  }
+
+  function hasCallExpression(expression) {
+    let currentExpression = expression;
+
+    // eslint-disable-next-line no-constant-condition
+    while (currentExpression != null) {
+      switch (currentExpression.type) {
+      case j.MemberExpression.name:
+        currentExpression = currentExpression.object;
+        break;
+      case j.CallExpression.name: return true;
+      default: return false;
+      }
+    }
+
+    return false;
   }
 
   function augmentMemberExpression(base, additional) {

--- a/packages/shopify-codemod/transforms/coffeescript-soak-to-condition.js
+++ b/packages/shopify-codemod/transforms/coffeescript-soak-to-condition.js
@@ -24,7 +24,7 @@ export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, 
     const parentPath = path.parentPath;
     const parentNode = parentPath.node;
 
-    if (j.VariableDeclarator.check(parentNode)) {
+    if (j.VariableDeclarator.check(parentNode) && parentPath.parentPath.node.declarations.length === 1) {
       parentPath.parentPath.parentPath.replace(
         j.ifStatement(
           condition,

--- a/packages/shopify-codemod/transforms/coffeescript-soak-to-condition.js
+++ b/packages/shopify-codemod/transforms/coffeescript-soak-to-condition.js
@@ -1,0 +1,209 @@
+export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, {printOptions = {}}) {
+  function handleOffensiveConditional(path) {
+    let memberExpression;
+    let condition;
+    let currentConsequent = path;
+
+    while (isOffensiveConditionalExpression(currentConsequent)) {
+      const currentTest = currentConsequent.get('test');
+      const newMembers = getBaseExpressionFromTest(currentTest);
+      memberExpression = augmentMemberExpression(memberExpression, newMembers);
+
+      const newCondition = isFunctionCheck(currentTest.value)
+        ? j.binaryExpression('===', j.unaryExpression('typeof', memberExpression), j.literal('function'))
+        : createLooseUndefinedCheck(memberExpression);
+
+      condition = (condition == null)
+        ? newCondition
+        : j.logicalExpression('&&', condition, newCondition);
+
+      currentConsequent = currentConsequent.get('consequent');
+    }
+
+    const finalValue = augmentMemberExpression(memberExpression, currentConsequent.value);
+    const parentPath = path.parentPath;
+    const parentNode = parentPath.node;
+
+    if (j.VariableDeclarator.check(parentNode)) {
+      parentPath.parentPath.parentPath.replace(
+        j.ifStatement(
+          condition,
+          j.blockStatement([
+            j.variableDeclaration('var', [
+              j.variableDeclarator(
+                parentPath.get('id').value,
+                finalValue
+              ),
+            ]),
+          ])
+        )
+      );
+    } else if (j.ExpressionStatement.check(parentNode)) {
+      parentPath.replace(
+        j.ifStatement(
+          condition,
+          j.blockStatement([j.expressionStatement(finalValue)])
+        )
+      );
+    } else if (j.AssignmentExpression.check(parentNode)) {
+      parentPath.parentPath.replace(
+        j.ifStatement(
+          condition,
+          j.blockStatement([
+            j.expressionStatement(
+              j.assignmentExpression(parentNode.operator, parentNode.left, finalValue)
+            ),
+          ])
+        )
+      );
+    } else if (j.ReturnStatement.check(parentNode)) {
+      parentPath.replace(
+        j.ifStatement(
+          condition,
+          j.blockStatement([j.returnStatement(finalValue)]),
+          j.blockStatement([j.returnStatement(j.literal(null))])
+        )
+      );
+    } else if (
+      j.IfStatement.check(parentNode) ||
+      j.WhileStatement.check(parentNode) ||
+      j.DoWhileStatement.check(parentNode)
+    ) {
+      path.replace(
+        j.logicalExpression('&&', condition, finalValue)
+      );
+    } else if (isLooseUndefinedCheck(parentNode)) {
+      parentPath.replace(
+        j.logicalExpression('&&', condition, createLooseUndefinedCheck(finalValue))
+      );
+    } else {
+      path.replace(
+        j.conditionalExpression(condition, finalValue, j.identifier('undefined'))
+      );
+    }
+  }
+
+  function createLooseUndefinedCheck(check) {
+    return j.binaryExpression('!=', check, j.literal(null));
+  }
+
+  function getBaseExpressionFromStrictTest(path) {
+    return path.get('left', 'left', 'argument').value;
+  }
+
+  function getBaseExpressionFromLooseTest(path) {
+    return path.get('left', 'right').value;
+  }
+
+  function getBaseExpressionFromFunctionTest(path) {
+    let argument = path.get('left', 'argument').value;
+
+    if (j.AssignmentExpression.check(argument.object)) {
+      argument = j.memberExpression(
+        argument.object.right,
+        argument.property
+      );
+    }
+
+    return argument;
+  }
+
+  function getBaseExpressionFromTest(path) {
+    if (isStrictUndefinedCheck(path.node)) {
+      return getBaseExpressionFromStrictTest(path);
+    } else if (isLooseUndefinedCheck(path.node)) {
+      return getBaseExpressionFromLooseTest(path);
+    } else {
+      return getBaseExpressionFromFunctionTest(path);
+    }
+  }
+
+  function augmentMemberExpression(base, additional) {
+    if (base == null) { return additional; }
+
+    const augmenters = [];
+    let currentNode = additional;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const node = currentNode;
+      if (j.MemberExpression.check(node)) {
+        augmenters.unshift(
+          (expression) => j.memberExpression(expression, node.property, node.computed)
+        );
+        currentNode = node.object;
+      } else if (j.CallExpression.check(node)) {
+        augmenters.unshift(
+          (expression) => {
+            if (j.MemberExpression.check(expression) && j.MemberExpression.check(node.callee) && expression.property.name === node.callee.property.name) {
+              return j.callExpression(expression.object, node.arguments);
+            } else {
+              return j.callExpression(expression, node.arguments);
+            }
+          }
+        );
+        currentNode = node.callee;
+      } else {
+        break;
+      }
+    }
+
+    return augmenters.reduce((expression, augmenter) => augmenter(expression), base);
+  }
+
+  function isFunctionCheck(node) {
+    return j.match(node, {
+      type: 'BinaryExpression',
+      operator: '===',
+      left: {type: 'UnaryExpression', operator: 'typeof'},
+    });
+  }
+
+  function isLooseUndefinedCheck(node) {
+    return j.match(node, {
+      type: 'BinaryExpression',
+      operator: '!=',
+      right: {type: 'Literal', value: null},
+    });
+  }
+
+  function isStrictUndefinedCheck(node) {
+    return j.match(node, {
+      type: 'LogicalExpression',
+      operator: '&&',
+      left: {
+        type: 'BinaryExpression',
+        operator: '!==',
+        left: {type: 'UnaryExpression', operator: 'typeof'},
+        right: {type: 'Literal', value: 'undefined'},
+      },
+      right: {
+        type: 'BinaryExpression',
+        operator: '!==',
+        right: {type: 'Literal', value: null},
+      },
+    });
+  }
+
+  function isOffensiveConditionalTest(node) {
+    return isStrictUndefinedCheck(node) || isLooseUndefinedCheck(node) || isFunctionCheck(node);
+  }
+
+  function isOffensiveConditionalExpression(path) {
+    return j.match(path.node, {
+      type: 'ConditionalExpression',
+      test: isOffensiveConditionalTest,
+      alternate: {
+        type: 'UnaryExpression',
+        operator: 'void',
+        argument: {type: 'Literal', value: 0},
+      },
+    });
+  }
+
+  return j(source)
+    .find(j.ConditionalExpression)
+    .filter((path) => isOffensiveConditionalExpression(path) && !isOffensiveConditionalExpression(path.parentPath))
+    .forEach(handleOffensiveConditional)
+    .toSource(printOptions);
+}


### PR DESCRIPTION
This PR adds a transform to make the output of CoffeeScript's `?` operator a lot cleaner. The output of that operator quickly becomes a complex, nested ternary operator, so this will be a big improvement.

cc/ @GoodForOneFare @bouk 