### PR TITLE
Transform sinon assertions to use methods that generate meaningful error messages

### DIFF
--- a/packages/esify/index.js
+++ b/packages/esify/index.js
@@ -21,6 +21,18 @@ var TRANSFORMS = [
   {path: 'js-codemod/transforms/object-shorthand'},
   {path: 'js-codemod/transforms/no-vars'},
   {path: 'js-codemod/transforms/unquote-properties'},
+  // Order is significant for these initial assert transforms; think carefully before reordering.
+  {path: 'shopify-codemod/transforms/assert/assert-false-to-assert-fail', test: true},
+  {path: 'shopify-codemod/transforms/assert/assert-to-assert-ok', test: true},
+  {path: 'shopify-codemod/transforms/assert/negated-assert-ok-to-assert-not-ok', test: true},
+  {path: 'shopify-codemod/transforms/assert/move-literals-to-expected-argument', test: true},
+  {path: 'shopify-codemod/transforms/assert/equality-comparisons-to-assertions', test: true},
+  // These transforms can be executed in any order.
+  {path: 'shopify-codemod/transforms/assert/called-equals-boolean-to-assert-called', test: true},
+  {path: 'shopify-codemod/transforms/assert/call-count-equals-to-assert-called', test: true},
+  {path: 'shopify-codemod/transforms/assert/called-method-to-assert-called', test: true},
+  {path: 'shopify-codemod/transforms/assert/called-with-methods-to-assert-called-with', test: true},
+  {path: 'shopify-codemod/transforms/assert/falsy-called-method-to-assert-not-called', test: true},
 ];
 
 var OPTIONS = loadOptions();

--- a/packages/shopify-codemod/test/fixtures/assert/assert-false-to-assert-fail/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/assert-false-to-assert-fail/basic.input.js
@@ -1,0 +1,7 @@
+assert(false, 'error message 1');
+assert.ok(false, 'error message 2');
+assert.ok(false, (`error message 3`));
+
+assert.ok(false, foo);
+assert.ok(false, 1); // Invalid, but assume it's not a failure message.
+assert.ok(true, 'error message');

--- a/packages/shopify-codemod/test/fixtures/assert/assert-false-to-assert-fail/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/assert-false-to-assert-fail/basic.output.js
@@ -1,0 +1,7 @@
+assert.fail('error message 1');
+assert.fail('error message 2');
+assert.fail(`error message 3`);
+
+assert.ok(false, foo);
+assert.ok(false, 1); // Invalid, but assume it's not a failure message.
+assert.ok(true, 'error message');

--- a/packages/shopify-codemod/test/fixtures/assert/assert-to-assert-ok/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/assert-to-assert-ok/basic.input.js
@@ -1,0 +1,8 @@
+assert(foo, 'error message');
+assert(foo.bar);
+assert(this.foo.bar);
+assert(this.foo.bar === that.bar.foo);
+
+assert(!foo);
+assert(!this.foo.bar);
+assert(!this.foo.bar());

--- a/packages/shopify-codemod/test/fixtures/assert/assert-to-assert-ok/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/assert-to-assert-ok/basic.output.js
@@ -1,0 +1,8 @@
+assert.ok(foo, 'error message');
+assert.ok(foo.bar);
+assert.ok(this.foo.bar);
+assert.ok(this.foo.bar === that.bar.foo);
+
+assert.ok(!foo);
+assert.ok(!this.foo.bar);
+assert.ok(!this.foo.bar());

--- a/packages/shopify-codemod/test/fixtures/assert/call-count-equals-to-assert-called/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/call-count-equals-to-assert-called/basic.input.js
@@ -1,0 +1,10 @@
+assert.equal(foo.callCount, 0, 'error message');
+assert.equal(foo.callCount, 1);
+assert.equal(foo.bar.callCount, 2);
+assert.equal(this.foo.bar.callCount, 3);
+
+assert.equal(foo.callCount, 4);
+assert.equal(foo.callCount, 10);
+
+assert.deepEqual(fn1.callCount, foo, 'callback count stayed the same');
+assert.deepEqual(fn1.callCount, foo, 'callback count stayed the same');

--- a/packages/shopify-codemod/test/fixtures/assert/call-count-equals-to-assert-called/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/call-count-equals-to-assert-called/basic.output.js
@@ -1,0 +1,10 @@
+assert.notCalled(foo);
+assert.calledOnce(foo);
+assert.calledTwice(foo.bar);
+assert.calledThrice(this.foo.bar);
+
+assert.callCount(foo, 4);
+assert.callCount(foo, 10);
+
+assert.callCount(fn1, foo);
+assert.callCount(fn1, foo);

--- a/packages/shopify-codemod/test/fixtures/assert/called-equals-boolean-to-assert-called/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/called-equals-boolean-to-assert-called/basic.input.js
@@ -1,0 +1,4 @@
+assert.equal(foo.notCalled, false, 'error message');
+assert.equal(foo.notCalled, true);
+assert.equal(foo.called, false);
+assert.equal(foo.called, true);

--- a/packages/shopify-codemod/test/fixtures/assert/called-equals-boolean-to-assert-called/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/called-equals-boolean-to-assert-called/basic.output.js
@@ -1,0 +1,4 @@
+assert.called(foo);
+assert.notCalled(foo);
+assert.notCalled(foo);
+assert.called(foo);

--- a/packages/shopify-codemod/test/fixtures/assert/called-method-to-assert-called/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/called-method-to-assert-called/basic.input.js
@@ -1,0 +1,11 @@
+assert.ok(foo.bar.called);
+assert.ok(foo.bar.calledOnce);
+assert.ok(foo.bar.calledTwice);
+assert.ok(foo.bar.calledThrice);
+
+assert.isTrue(foo.bar.called);
+
+assert.isTrue(foo.bar.notCalled);
+assert.isFalse(foo.bar.called);
+assert.isFalse(foo.bar.notCalled);
+assert.notOk(foo.bar.called);

--- a/packages/shopify-codemod/test/fixtures/assert/called-method-to-assert-called/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/called-method-to-assert-called/basic.output.js
@@ -1,0 +1,11 @@
+assert.called(foo.bar);
+assert.calledOnce(foo.bar);
+assert.calledTwice(foo.bar);
+assert.calledThrice(foo.bar);
+
+assert.called(foo.bar);
+
+assert.notCalled(foo.bar);
+assert.notCalled(foo.bar);
+assert.called(foo.bar);
+assert.notCalled(foo.bar);

--- a/packages/shopify-codemod/test/fixtures/assert/called-with-methods-to-assert-called-with/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/called-with-methods-to-assert-called-with/basic.input.js
@@ -1,0 +1,8 @@
+assert.isTrue(foo.calledWith(bar, 'qux'), 'error message');
+assert.isTrue(foo.calledWithMatch({onlyKeys: ['foo', 'bar']}), 'error message');
+assert.isTrue(foo.calledWithMatch(sinon.match.string, sinon.match.object, sinon.match.object));
+assert.isTrue(foo.calledWithExactly(bar, qux), 'error message');
+
+assert.ok(foo.calledWith(bar, qux), 'error message');
+
+assert.isTrue(foo.neverCalledWith(bar, qux));

--- a/packages/shopify-codemod/test/fixtures/assert/called-with-methods-to-assert-called-with/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/called-with-methods-to-assert-called-with/basic.output.js
@@ -1,0 +1,8 @@
+assert.calledWith(foo, bar, 'qux');
+assert.calledWithMatch(foo, {onlyKeys: ['foo', 'bar']});
+assert.calledWithMatch(foo, sinon.match.string, sinon.match.object, sinon.match.object);
+assert.calledWithExactly(foo, bar, qux);
+
+assert.calledWith(foo, bar, qux);
+
+assert.neverCalledWith(foo, bar, qux);

--- a/packages/shopify-codemod/test/fixtures/assert/equality-comparisons-to-assertions/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/equality-comparisons-to-assertions/basic.input.js
@@ -1,0 +1,6 @@
+assert.isTrue('foo' === bar, 'error message');
+assert.isTrue(foo !== bar);
+assert.isTrue(this.foo === 'bar');
+
+assert.ok(foo === bar);
+assert.ok(this.foo !== bar);

--- a/packages/shopify-codemod/test/fixtures/assert/equality-comparisons-to-assertions/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/equality-comparisons-to-assertions/basic.output.js
@@ -1,0 +1,6 @@
+assert.strictEqual('foo', bar, 'error message');
+assert.notStrictEqual(foo, bar);
+assert.strictEqual(this.foo, 'bar');
+
+assert.strictEqual(foo, bar);
+assert.notStrictEqual(this.foo, bar);

--- a/packages/shopify-codemod/test/fixtures/assert/falsy-called-method-to-assert-not-called/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/falsy-called-method-to-assert-not-called/basic.input.js
@@ -1,0 +1,2 @@
+assert.notOk(foo.calledWith(bar, qux));
+assert.isFalse(foo.calledWithMatch(bar));

--- a/packages/shopify-codemod/test/fixtures/assert/falsy-called-method-to-assert-not-called/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/falsy-called-method-to-assert-not-called/basic.output.js
@@ -1,0 +1,2 @@
+assert.neverCalledWith(foo, bar, qux);
+assert.neverCalledWithMatch(foo, bar);

--- a/packages/shopify-codemod/test/fixtures/assert/move-literals-to-expected-argument/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/move-literals-to-expected-argument/basic.input.js
@@ -1,0 +1,13 @@
+assert.equal(5, foo, 'error message');
+assert.equal('foo', bar);
+assert.equal('foo', this.foo.bar());
+assert.equal('foo', !bar);
+assert.equal(null, foo);
+assert.equal((`foo`), bar);
+
+assert.equal([], foo);
+assert.deepEqual({}, foo, 'error message');
+assert.notDeepEqual({}, foo);
+assert.notEqual(1, foo);
+assert.notStrictEqual(2, foo);
+assert.strictEqual('foo', foo);

--- a/packages/shopify-codemod/test/fixtures/assert/move-literals-to-expected-argument/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/move-literals-to-expected-argument/basic.output.js
@@ -1,0 +1,13 @@
+assert.equal(foo, 5, 'error message');
+assert.equal(bar, 'foo');
+assert.equal(this.foo.bar(), 'foo');
+assert.equal(!bar, 'foo');
+assert.equal(foo, null);
+assert.equal(bar, `foo`);
+
+assert.equal(foo, []);
+assert.deepEqual(foo, {}, 'error message');
+assert.notDeepEqual(foo, {});
+assert.notEqual(foo, 1);
+assert.notStrictEqual(foo, 2);
+assert.strictEqual(foo, 'foo');

--- a/packages/shopify-codemod/test/fixtures/assert/move-literals-to-expected-argument/ignored.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/move-literals-to-expected-argument/ignored.input.js
@@ -1,0 +1,5 @@
+// Valid assertions that should *not* be altered by the transform.
+assert.equal(foo, [], 'should not change');
+assert.equal(foo, bar, 'should not change');
+assert.equal(foo, 'bar', 'should not change');
+assert.equal(foo, 'bar', (`should not change`));

--- a/packages/shopify-codemod/test/fixtures/assert/move-literals-to-expected-argument/ignored.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/move-literals-to-expected-argument/ignored.output.js
@@ -1,0 +1,5 @@
+// Valid assertions that should *not* be altered by the transform.
+assert.equal(foo, [], 'should not change');
+assert.equal(foo, bar, 'should not change');
+assert.equal(foo, 'bar', 'should not change');
+assert.equal(foo, 'bar', (`should not change`));

--- a/packages/shopify-codemod/test/fixtures/assert/negated-assert-ok-to-assert-not-ok/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/assert/negated-assert-ok-to-assert-not-ok/basic.input.js
@@ -1,0 +1,4 @@
+assert.ok(!foo, 'error message');
+assert.ok(!foo.bar);
+assert.ok(!this.foo.bar);
+assert.ok(!(foobar === barfoo));

--- a/packages/shopify-codemod/test/fixtures/assert/negated-assert-ok-to-assert-not-ok/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/assert/negated-assert-ok-to-assert-not-ok/basic.output.js
@@ -1,0 +1,4 @@
+assert.notOk(foo, 'error message');
+assert.notOk(foo.bar);
+assert.notOk(this.foo.bar);
+assert.notOk(foobar === barfoo);

--- a/packages/shopify-codemod/test/transforms/assert/assert-false-to-assert-fail.test.js
+++ b/packages/shopify-codemod/test/transforms/assert/assert-false-to-assert-fail.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import assertFalseToAssertFail from 'assert/assert-false-to-assert-fail';
+
+describe('assert/assertFalseToAssertFail', () => {
+  it('transforms assert false to assert.fail', () => {
+    expect(assertFalseToAssertFail).to.transform('assert/assert-false-to-assert-fail/basic');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/assert/assert-to-assert-ok.test.js
+++ b/packages/shopify-codemod/test/transforms/assert/assert-to-assert-ok.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import assertToAssertOk from 'assert/assert-to-assert-ok';
+
+describe('assert/assertToAssertOk', () => {
+  it('transforms assert to assert.ok', () => {
+    expect(assertToAssertOk).to.transform('assert/assert-to-assert-ok/basic');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/assert/call-count-equals-to-assert-called.test.js
+++ b/packages/shopify-codemod/test/transforms/assert/call-count-equals-to-assert-called.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import transform from 'assert/call-count-equals-to-assert-called';
+
+describe('assert/callCountEqualsToAssertCalled', () => {
+  it('tranforms calledWith method calls to assertions with better error reporting', () => {
+    expect(transform).to.transform('assert/call-count-equals-to-assert-called/basic');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/assert/called-equals-boolean-to-assert-called.test.js
+++ b/packages/shopify-codemod/test/transforms/assert/called-equals-boolean-to-assert-called.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import transform from 'assert/called-equals-boolean-to-assert-called';
+
+describe('assert/calledEqualsToAssertCalled', () => {
+  it('tranforms called equals boolean to assertions with better error reporting', () => {
+    expect(transform).to.transform('assert/called-equals-boolean-to-assert-called/basic');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/assert/called-method-to-assert-called.test.js
+++ b/packages/shopify-codemod/test/transforms/assert/called-method-to-assert-called.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import transform from 'assert/called-method-to-assert-called';
+
+describe('assert/calledMethodToAssertCalled', () => {
+  it('transforms called method calls to assertions with better error reporting', () => {
+    expect(transform).to.transform('assert/called-method-to-assert-called/basic');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/assert/called-with-methods-to-assert-called-with.test.js
+++ b/packages/shopify-codemod/test/transforms/assert/called-with-methods-to-assert-called-with.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import transform from 'assert/called-with-methods-to-assert-called-with';
+
+describe('assert/calledWithMethodsToAssertCalledWith', () => {
+  it('transforms calledWidth method calls to assertions with better error reporting', () => {
+    expect(transform).to.transform('assert/called-with-methods-to-assert-called-with/basic');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/assert/equality-comparisons-to-assertions.test.js
+++ b/packages/shopify-codemod/test/transforms/assert/equality-comparisons-to-assertions.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import transform from 'assert/equality-comparisons-to-assertions';
+
+describe('assert/equalityComparisonsToAssertions', () => {
+  it('transforms equality comparisons to assertions', () => {
+    expect(transform).to.transform('assert/equality-comparisons-to-assertions/basic');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/assert/falsy-called-method-to-assert-not-called.test.js
+++ b/packages/shopify-codemod/test/transforms/assert/falsy-called-method-to-assert-not-called.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import transform from 'assert/falsy-called-method-to-assert-not-called';
+
+describe('assert/falsyCalledMethodToAssertNotCalled', () => {
+  it('transforms falsy called checks to never called assertions', () => {
+    expect(transform).to.transform('assert/falsy-called-method-to-assert-not-called/basic');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/assert/move-literals-to-expected-argument.test.js
+++ b/packages/shopify-codemod/test/transforms/assert/move-literals-to-expected-argument.test.js
@@ -1,0 +1,12 @@
+import 'test-helper';
+import transform from 'assert/move-literals-to-expected-argument';
+
+describe('assert/moveLiteralsToExpectedArgument', () => {
+  it('moves literals in actual argument slot to expected argument slot', () => {
+    expect(transform).to.transform('assert/move-literals-to-expected-argument/basic');
+  });
+
+  it('ignores valid assertions', () => {
+    expect(transform).to.transform('assert/move-literals-to-expected-argument/ignored');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/assert/negated-assert-ok-to-assert-not-ok.test.js
+++ b/packages/shopify-codemod/test/transforms/assert/negated-assert-ok-to-assert-not-ok.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import transform from 'assert/negated-assert-ok-to-assert-not-ok';
+
+describe('assert/negatedAssertOkToAssertNotOk', () => {
+  it('transforms negated ok assertions to assert.notOk', () => {
+    expect(transform).to.transform('assert/negated-assert-ok-to-assert-not-ok/basic');
+  });
+});

--- a/packages/shopify-codemod/transforms/assert/assert-false-to-assert-fail.js
+++ b/packages/shopify-codemod/transforms/assert/assert-false-to-assert-fail.js
@@ -1,0 +1,20 @@
+import {createAssertion, isAssert} from './utils';
+
+export default function assertFalseToAssertFail({source}, {jscodeshift: j}, {printOptions = {}}) {
+  function isStringArgument(argument) {
+    return argument != null && (typeof argument.value === 'string' || j.TemplateLiteral.check(argument));
+  }
+
+  return j(source)
+    .find(j.CallExpression, {
+      callee: (callee) => callee.name === 'assert' || isAssert('ok'),
+      arguments: (args) =>
+        args.length === 2 &&
+        args[0].value === false &&
+        isStringArgument(args[1]),
+    })
+    .replaceWith(({node: {arguments: [, failMessage]}}) =>
+      createAssertion('fail', [failMessage])
+    )
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/assert/assert-to-assert-ok.js
+++ b/packages/shopify-codemod/transforms/assert/assert-to-assert-ok.js
@@ -1,0 +1,15 @@
+import {createAssertion} from './utils';
+
+export default function assertToAssertOk({source}, {jscodeshift: j}, {printOptions = {}}) {
+  return j(source)
+    .find(j.CallExpression, {
+      callee: {
+        type: j.Identifier.name,
+        name: 'assert',
+      },
+    })
+    .replaceWith(({node}) =>
+      createAssertion('ok', node.arguments)
+    )
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/assert/call-count-equals-to-assert-called.js
+++ b/packages/shopify-codemod/transforms/assert/call-count-equals-to-assert-called.js
@@ -1,0 +1,46 @@
+import {createAssertion, isAssert, isMemberCall} from './utils';
+
+export default function callCountEqualsToAssertCalled({source}, {jscodeshift: j}, {printOptions = {}}) {
+  function intToCallMethodName(callCount) {
+    return {
+      0: 'notCalled',
+      1: 'calledOnce',
+      2: 'calledTwice',
+      3: 'calledThrice',
+    }[callCount];
+  }
+
+  const sourceAST = j(source);
+  sourceAST
+    .find(j.CallExpression, {
+      callee: isAssert('equal', 'strictEqual', 'deepEqual'),
+      arguments: {
+        0: isMemberCall('callCount'),
+        1: (node) => node.value >= 0 && node.value <= 3,
+      },
+    })
+    .replaceWith(({node: {arguments: [actualArg, expectedArg]}}) => {
+      const assertionName = intToCallMethodName(expectedArg.value);
+
+      return j.callExpression(
+        j.memberExpression(j.identifier('assert'), j.identifier(assertionName), false),
+        [actualArg.object]
+      );
+    });
+
+  return sourceAST
+    .find(j.CallExpression, {
+      callee: isAssert('equal', 'strictEqual', 'deepEqual'),
+      arguments: {
+        0: isMemberCall('callCount'),
+        1: (node) =>
+          j.MemberExpression.check(node) ||
+          j.Identifier.check(node) ||
+          j.Literal.check(node) && isFinite(node.value),
+      },
+    })
+    .replaceWith(({node: {arguments: [actualArg, expectedArg]}}) =>
+      createAssertion('callCount', [actualArg.object, expectedArg])
+    )
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/assert/called-equals-boolean-to-assert-called.js
+++ b/packages/shopify-codemod/transforms/assert/called-equals-boolean-to-assert-called.js
@@ -1,0 +1,22 @@
+import {createAssertion, isAssert, isMemberCall} from './utils';
+
+export default function calledEqualsBooleanToAssertCalled({source}, {jscodeshift: j}, {printOptions = {}}) {
+  return j(source)
+    .find(j.CallExpression, {
+      callee: isAssert('deepEqual', 'equal', 'strictEqual'),
+      arguments: {
+        0: isMemberCall('called', 'notCalled'),
+        1: (node) => node.value === true || node.value === false,
+      },
+    })
+    .replaceWith(({node: {arguments: [actualArg, expectedArg]}}) => {
+      const isPositiveAssertion = (actualArg.property.name === 'called');
+      const isPositiveExpectation = expectedArg.value;
+      const newAssertName = (isPositiveAssertion !== isPositiveExpectation)
+        ? 'notCalled'
+        : 'called';
+
+      return createAssertion(newAssertName, [actualArg.object]);
+    })
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/assert/called-method-to-assert-called.js
+++ b/packages/shopify-codemod/transforms/assert/called-method-to-assert-called.js
@@ -1,0 +1,34 @@
+import {createAssertion, isAssert, isMemberCall} from './utils';
+
+export default function calledMethodToAssertCalled({source}, {jscodeshift: j}, {printOptions = {}}) {
+  function invertCalledAssertionName(methodName) {
+    return methodName === 'called' ? 'notCalled' : 'called';
+  }
+
+  const sourceAST = j(source);
+  sourceAST
+    .find(j.CallExpression, {
+      callee: isAssert('isFalse', 'notOk'),
+      arguments: {
+        0: isMemberCall('called', 'notCalled'),
+      },
+    })
+    .replaceWith(({node: {arguments: [callArg]}}) =>
+      createAssertion(
+        invertCalledAssertionName(callArg.property.name),
+        [callArg.object]
+      )
+    );
+
+  return sourceAST
+    .find(j.CallExpression, {
+      callee: isAssert('isTrue', 'ok'),
+      arguments: {
+        0: isMemberCall('called', 'calledOnce', 'calledTwice', 'calledThrice', 'notCalled'),
+      },
+    })
+    .replaceWith(({node: {arguments: [callArg]}}) =>
+      createAssertion(callArg.property, [callArg.object])
+    )
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/assert/called-with-methods-to-assert-called-with.js
+++ b/packages/shopify-codemod/transforms/assert/called-with-methods-to-assert-called-with.js
@@ -1,0 +1,21 @@
+import {createAssertion, isAssert, isMemberCall} from './utils';
+
+export default function calledWithMethodsToAssertCalledWith({source}, {jscodeshift: j}, {printOptions = {}}) {
+  return j(source)
+    .find(j.CallExpression, {
+      callee: isAssert('isTrue', 'ok'),
+      arguments: {
+        0: {
+          type: j.CallExpression.name,
+          callee: isMemberCall('calledWith', 'calledWithMatch', 'calledWithExactly', 'neverCalledWith'),
+        },
+      },
+    })
+    .replaceWith(({node: {arguments: [callArg]}}) =>
+      createAssertion(
+        callArg.callee.property,
+        [callArg.callee.object, ...callArg.arguments]
+      )
+    )
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/assert/equality-comparisons-to-assertions.js
+++ b/packages/shopify-codemod/transforms/assert/equality-comparisons-to-assertions.js
@@ -1,0 +1,25 @@
+import {createAssertion, isAssert} from './utils';
+
+const EQUALITY_OPERATORS = new Set(['===', '!==']);
+
+export default function equalityComparisonsToAssertions({source}, {jscodeshift: j}, {printOptions = {}}) {
+  return j(source)
+    .find(j.CallExpression, {
+      callee: isAssert('isTrue', 'ok'),
+      arguments: {
+        0: {
+          type: j.BinaryExpression.name,
+          operator: (op) => EQUALITY_OPERATORS.has(op),
+        },
+      },
+    })
+    .replaceWith(({node: {arguments: [comparison, ...otherArgs]}}) => {
+      const assertionName = comparison.operator === '===' ? 'strictEqual' : 'notStrictEqual';
+
+      return createAssertion(
+        assertionName,
+        [comparison.left, comparison.right, ...otherArgs]
+      );
+    })
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/assert/falsy-called-method-to-assert-not-called.js
+++ b/packages/shopify-codemod/transforms/assert/falsy-called-method-to-assert-not-called.js
@@ -1,0 +1,29 @@
+import {createAssertion, isAssert, isMemberCall} from './utils';
+
+export default function falsyCalledMethodToAssertNotCalled({source}, {jscodeshift: j}, {printOptions = {}}) {
+  function invertCalledAssertionName(assertionName) {
+    return {
+      called: 'notCalled',
+      calledWith: 'neverCalledWith',
+      calledWithMatch: 'neverCalledWithMatch',
+    }[assertionName];
+  }
+
+  return j(source)
+    .find(j.CallExpression, {
+      callee: isAssert('notOk', 'isFalse'),
+      arguments: {
+        0: {
+          type: j.CallExpression.name,
+          callee: isMemberCall('calledWith', 'calledWithMatch'),
+        },
+      },
+    })
+    .replaceWith(({node: {arguments: [{callee, arguments: callArgs}]}}) =>
+      createAssertion(
+        invertCalledAssertionName(callee.property.name),
+        [callee.object, ...callArgs]
+      )
+    )
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/assert/move-literals-to-expected-argument.js
+++ b/packages/shopify-codemod/transforms/assert/move-literals-to-expected-argument.js
@@ -1,0 +1,31 @@
+import {createAssertion, isAssert} from './utils';
+import jscodeshift from 'jscodeshift';
+
+const HARDCODED_VALUE_TYPES = new Set([
+  jscodeshift.ArrayExpression.name,
+  jscodeshift.Literal.name,
+  jscodeshift.ObjectExpression.name,
+  jscodeshift.TemplateLiteral.name,
+]);
+
+export default function moveLiteralsToExpectedArgument({source}, {jscodeshift: j}, {printOptions = {}}) {
+  return j(source)
+    .find(j.CallExpression, {
+      callee: isAssert('equal', 'notEqual', 'strictEqual', 'notStrictEqual', 'deepEqual', 'notDeepEqual'),
+      arguments: {
+        0: {
+          type: (type) => HARDCODED_VALUE_TYPES.has(type),
+        },
+        1: {
+          type: (type) => !HARDCODED_VALUE_TYPES.has(type),
+        },
+      },
+    })
+    .replaceWith(({node: {callee, arguments: args}}) =>
+      createAssertion(
+        callee.property,
+        [args[1], args[0], ...args.slice(2)]
+      )
+    )
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/assert/negated-assert-ok-to-assert-not-ok.js
+++ b/packages/shopify-codemod/transforms/assert/negated-assert-ok-to-assert-not-ok.js
@@ -1,0 +1,18 @@
+import {createAssertion, isAssert} from './utils';
+
+export default function negatedAssertOkToAssertNotOk({source}, {jscodeshift: j}, {printOptions = {}}) {
+  return j(source)
+    .find(j.CallExpression, {
+      callee: isAssert('ok'),
+      arguments: {
+        0: {
+          type: j.UnaryExpression.name,
+          operator: '!',
+        },
+      },
+    })
+    .replaceWith(({node: {arguments: [negation, ...otherArgs]}}) =>
+      createAssertion('notOk', [negation.argument, ...otherArgs])
+    )
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/assert/utils.js
+++ b/packages/shopify-codemod/transforms/assert/utils.js
@@ -1,0 +1,32 @@
+import j from 'jscodeshift';
+
+export function createAssertion(assertionNameOrProperty, args) {
+  const assertionName = (assertionNameOrProperty.name != null)
+    ? assertionNameOrProperty.name
+    : assertionNameOrProperty;
+
+  return j.callExpression(
+    j.memberExpression(j.identifier('assert'), j.identifier(assertionName), false),
+    args
+  );
+}
+
+export function isAssert(...validAssertionNames) {
+  return {
+    object: {
+      name: 'assert',
+    },
+    property: {
+      name: (name) => validAssertionNames.indexOf(name) > -1,
+    },
+  };
+}
+
+export function isMemberCall(...propertyNames) {
+  return {
+    type: j.MemberExpression.name,
+    property: {
+      name: (name) => propertyNames.indexOf(name) > -1,
+    },
+  };
+}


### PR DESCRIPTION
* Does some cleanup to get consistently searchable assertions
* Turns any inline `foo.called`-like assertions into `assert.called(foo)`-like assertions

Note: 2 cases won't be cleaned up because they don't map to a sinon assertion.  They'll be handled in another PR.
- `assert.isFalse(foo.threw())`
- `assert.isFalse(foo.calledWithExactly(bar))`

/cc @lemonmade, @fandy