### PR TITLE
Make `esify` usable by other projects

### DIFF
--- a/packages/esify/README.md
+++ b/packages/esify/README.md
@@ -15,3 +15,37 @@ From the root of the Shopify directory, run this script with a single, relative 
 ```sh
 esify app/assets/javascripts/admin/lib/*.coffee
 ```
+
+You can provide custom options to `esify` by adding an `esify.config.js` file to the directory from which you are running the `esify` command. An example configuration is shown below:
+
+```js
+// your-project/esify.config.js
+var path = require('path');
+
+module.exports = {
+  // The global namespaces used in your current JavaScript code.
+  appGlobalIdentifiers: ['Shopify'],
+
+  // The root folder for your JavaScripts
+  javaScriptSourceLocation: path.join(__dirname, 'app/assets/javascripts'),
+
+  // The output style for your code
+  printOptions: {
+    quote: 'single',
+    trailingComma: true,
+    tabWidth: 2,
+    wrapColumn: 1000,
+  },
+
+  // The options for the mocha-context-to-global-reference shopify-codemod transform
+  testContextToGlobals: {
+    testClock: {
+      properties: ['clock'],
+      replace: true,
+    },
+    sandbox: {
+      properties: ['spy', 'stub', 'mock', 'server', 'requests'],
+    },
+  },
+}
+```

--- a/packages/esify/README.md
+++ b/packages/esify/README.md
@@ -29,7 +29,8 @@ module.exports = {
   // The root folder for your JavaScripts
   javaScriptSourceLocation: path.join(__dirname, 'app/assets/javascripts'),
 
-  // The output style for your code
+  // The output style for your code. You can see all available options in the Recast docs:
+  // https://github.com/benjamn/recast/blob/master/lib/options.js
   printOptions: {
     quote: 'single',
     trailingComma: true,

--- a/packages/esify/bin/esify
+++ b/packages/esify/bin/esify
@@ -5,10 +5,6 @@ var glob = require('glob');
 var path = require('path');
 var transform = require('..');
 
-if (!/shopify/i.test(path.basename(process.cwd()))) {
-  throw new Error('You must run this command from the root of the Shopify repo.');
-}
-
 var pattern = process.argv[2];
 var files = getFiles(pattern);
 var errors = {};

--- a/packages/esify/index.js
+++ b/packages/esify/index.js
@@ -23,25 +23,33 @@ var TRANSFORMS = [
   {path: 'js-codemod/transforms/unquote-properties'},
 ];
 
-var OPTIONS = {
-  appGlobalIdentifiers: ['Shopify', 'Sello'],
-  javascriptSourceLocation: path.join(process.cwd(), 'app/assets/javascripts'),
-  printOptions: {
-    quote: 'single',
-    trailingComma: true,
-    tabWidth: 2,
-    wrapColumn: 1000,
-  },
-  testContextToGlobals: {
-    testClock: {
-      properties: ['clock'],
-      replace: true,
-    },
-    sandbox: {
-      properties: ['spy', 'stub', 'mock', 'server', 'requests'],
-    },
-  },
-};
+var OPTIONS = loadOptions();
+
+function loadOptions() {
+  try {
+    return require(path.join(process.cwd(), 'esify.config'));
+  } catch (error) {
+    return {
+      appGlobalIdentifiers: ['Shopify', 'Sello'],
+      javascriptSourceLocation: path.join(process.cwd(), 'app/assets/javascripts'),
+      printOptions: {
+        quote: 'single',
+        trailingComma: true,
+        tabWidth: 2,
+        wrapColumn: 1000,
+      },
+      testContextToGlobals: {
+        testClock: {
+          properties: ['clock'],
+          replace: true,
+        },
+        sandbox: {
+          properties: ['spy', 'stub', 'mock', 'server', 'requests'],
+        },
+      },
+    };
+  }
+}
 
 function runTransform(code, name) {
   var module = require(name);

--- a/packages/esify/package.json
+++ b/packages/esify/package.json
@@ -10,8 +10,8 @@
       "plugin:shopify/node"
     ],
     "rules": {
-      "no-console": "off",
-      "no-sync": "off"
+      "no-console": 0,
+      "no-sync": 0
     }
   },
   "bin": "./bin/esify",


### PR DESCRIPTION
This PR lets other projects use `esify` by removing some values that were hardcoded to Shopify, and allowing custom options to be set using a configuration file.

cc/ @bouk @GoodForOneFare @tylerball 