### PR TITLE
Prefer equivalent JavaScript file for multiple global-to-import matches

### DIFF
--- a/packages/chai-jscodeshift/index.js
+++ b/packages/chai-jscodeshift/index.js
@@ -22,27 +22,38 @@ module.exports = function chaiJSCodeShift(options) {
     var Assertion = chaiOptions.Assertion;
     var assert = chaiOptions.assert;
 
-    function transform(fixture, transformOptions) {
-      var transformer = this._obj;
-
+    function transformFixtureWithOptions(transformer, fixture, transformOptions) {
       var inputPath = finalConfig.inputFixturePath(fixture, finalConfig.fixtureDirectory);
-      var outputPath = finalConfig.outputFixturePath(fixture, finalConfig.fixtureDirectory);
 
       var input = fs.readFileSync(inputPath, 'utf8');
-      var output = fs.readFileSync(outputPath, 'utf8').trim();
-      var transformed = transformer(
+      return transformer(
         {source: input, path: inputPath},
         {jscodeshift: jscodeshift},
         merge({}, finalConfig.transformOptions, transformOptions || {})
       ).trim();
+    }
 
+    function transform(fixture, transformOptions) {
+      var outputPath = finalConfig.outputFixturePath(fixture, finalConfig.fixtureDirectory);
+      var output = fs.readFileSync(outputPath, 'utf8').trim();
+      var transformed = transformFixtureWithOptions(this._obj, fixture, transformOptions);
       new Assertion(transformed).to.equal(output);
     }
 
+    function throwWhileTransforming(fixture, error, transformOptions) {
+      var transformer = this._obj;
+      new Assertion(function() { transformFixtureWithOptions(transformer, fixture, transformOptions); }).to.throw(error);
+    }
+
     Assertion.addMethod('transform', transform);
+    Assertion.addMethod('throwWhileTransforming', throwWhileTransforming);
 
     assert.transforms = function(transformer, fixture, transformerOptions) {
       return (new Assertion(transformer)).to.transform(fixture, transformerOptions || {});
+    };
+
+    assert.throwsWhileTransforming = function(transformer, fixture, error, transformerOptions) {
+      return (new Assertion(transformer)).to.throwWhileTransforming(fixture, error, transformerOptions);
     };
   };
 

--- a/packages/shopify-codemod/test/fixtures/global-reference-to-import/multiple-matches/basic-invalid.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-reference-to-import/multiple-matches/basic-invalid.input.js
@@ -1,0 +1,1 @@
+console.log(App.Components.InvalidMultipleMatch);

--- a/packages/shopify-codemod/test/fixtures/global-reference-to-import/multiple-matches/basic-valid.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-reference-to-import/multiple-matches/basic-valid.input.js
@@ -1,0 +1,1 @@
+console.log(App.Components.ValidMultipleMatch);

--- a/packages/shopify-codemod/test/fixtures/global-reference-to-import/multiple-matches/basic-valid.output.js
+++ b/packages/shopify-codemod/test/fixtures/global-reference-to-import/multiple-matches/basic-valid.output.js
@@ -1,0 +1,2 @@
+import ValidMultipleMatch from 'app/components/valid-multiple-match';
+console.log(ValidMultipleMatch);

--- a/packages/shopify-codemod/test/fixtures/global-reference-to-import/multiple-matches/nested-invalid.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-reference-to-import/multiple-matches/nested-invalid.input.js
@@ -1,0 +1,1 @@
+console.log(App.Components.InvalidMultipleMatchThree);

--- a/packages/shopify-codemod/test/fixtures/javascripts/app/components/invalid-multiple-two.js
+++ b/packages/shopify-codemod/test/fixtures/javascripts/app/components/invalid-multiple-two.js
@@ -1,0 +1,3 @@
+'expose App.Components.InvalidMultipleMatch'
+
+export default class InvalidMultipleMatch {}

--- a/packages/shopify-codemod/test/fixtures/javascripts/app/components/invalid_multiple_one.coffee
+++ b/packages/shopify-codemod/test/fixtures/javascripts/app/components/invalid_multiple_one.coffee
@@ -1,0 +1,1 @@
+class App.Components.InvalidMultipleMatch

--- a/packages/shopify-codemod/test/fixtures/javascripts/app/components/invalid_multiple_three.coffee
+++ b/packages/shopify-codemod/test/fixtures/javascripts/app/components/invalid_multiple_three.coffee
@@ -1,0 +1,1 @@
+class App.Components.InvalidMultipleMatchThree

--- a/packages/shopify-codemod/test/fixtures/javascripts/app/components/nested/invalid-multiple-three.js
+++ b/packages/shopify-codemod/test/fixtures/javascripts/app/components/nested/invalid-multiple-three.js
@@ -1,0 +1,3 @@
+'expose App.Components.InvalidMultipleMatchThree';
+
+export default class InvalidMultipleMatchThree {}

--- a/packages/shopify-codemod/test/fixtures/javascripts/app/components/valid-multiple-match.js
+++ b/packages/shopify-codemod/test/fixtures/javascripts/app/components/valid-multiple-match.js
@@ -1,0 +1,3 @@
+'expose App.Components.ValidMultipleMatch'
+
+export default class ValidMultipleMatch {}

--- a/packages/shopify-codemod/test/fixtures/javascripts/app/components/valid_multiple_match.coffee
+++ b/packages/shopify-codemod/test/fixtures/javascripts/app/components/valid_multiple_match.coffee
@@ -1,0 +1,1 @@
+class App.Components.ValidMultipleMatch

--- a/packages/shopify-codemod/test/transforms/global-reference-to-import.test.js
+++ b/packages/shopify-codemod/test/transforms/global-reference-to-import.test.js
@@ -13,4 +13,22 @@ describe('globalReferenceToImport', () => {
   it('preserves directives', () => {
     expect(globalReferenceToImport).to.transform('global-reference-to-import/directive');
   });
+
+  it('throws an error when multiple exports match', () => {
+    expect(globalReferenceToImport).to.throwWhileTransforming(
+      'global-reference-to-import/multiple-matches/basic-invalid',
+      /Found multiple definitions for App\.Components\.InvalidMultipleMatch/
+    );
+  });
+
+  it('throws an error when multiple exports match and the files are not in the same location', () => {
+    expect(globalReferenceToImport).to.throwWhileTransforming(
+      'global-reference-to-import/multiple-matches/nested-invalid',
+      /Found multiple definitions for App\.Components\.InvalidMultipleMatchThree/
+    );
+  });
+
+  it('imports from a JavaScript file when there are multiple matches with comparable paths', () => {
+    expect(globalReferenceToImport).to.transform('global-reference-to-import/multiple-matches/basic-valid');
+  });
 });


### PR DESCRIPTION
Fixes #59. This PR improves `global-reference-to-import` to allow duplicate import sources in one case: when there are exactly two matches, and they are an equivalent JS/ CS pair (same directory, JS name is dash-cased). I also added another assertion to `chai-jscodeshift` to expect a thrown error when transforming a particular fixture.

cc/ @bouk @GoodForOneFare @fandy 