### PR TITLE
esify now accepts multiple files/globs

### DIFF
--- a/packages/esify/bin/esify
+++ b/packages/esify/bin/esify
@@ -5,8 +5,8 @@ var glob = require('glob');
 var path = require('path');
 var transform = require('..');
 
-var pattern = process.argv[2];
-var files = getFiles(pattern);
+var patterns = process.argv.slice(2);
+var files = getFiles(patterns);
 var errors = {};
 
 if (files.length === 0) {
@@ -30,14 +30,18 @@ if (errorKeys.length > 0) {
   });
 }
 
-function getFiles(filePattern) {
-  if (filePattern == null) {
-    throw new Error('Pass in a .coffee file, or glob pattern.');
+function getFiles(filePatterns) {
+  if (filePatterns == null || filePatterns.length === 0) {
+    throw new Error('Pass in .coffee files, or glob patterns.');
   }
 
-  return glob
-    .sync(filePattern, {ignore: ['node_modules/**', 'vendor/**']})
-    .filter(function(filePath) { return filePath.match(/\.coffee$/); });
+  return filePatterns.reduce(function(result, filePattern) {
+    return result.concat(
+      glob
+        .sync(filePattern, {ignore: ['node_modules/**', 'vendor/**']})
+        .filter(function(filePath) { return filePath.match(/\.coffee$/); })
+    );
+  }, []);
 }
 
 function handleFile(filePath) {


### PR DESCRIPTION
Gets esify to accept multiple input args, e.g., 
```esify app/assets/javascripts/sello/**/*.coffee test/sello-javascripts/**/*.coffee```

I found this very useful while troubleshooting our soak transform problems, but I'm okay with not merging this if it's not generally useful.

/cc @lemonmade @bouk 