### PR TITLE
Improve global to import transform

### DIFF
--- a/packages/shopify-codemod/test/fixtures/global-reference-to-import/self-referencing.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-reference-to-import/self-referencing.input.js
@@ -1,0 +1,11 @@
+'expose App.A';
+
+export default class A {
+  static b() {
+    App.A.c();
+  }
+
+  static c() {
+
+  }
+}

--- a/packages/shopify-codemod/test/fixtures/global-reference-to-import/self-referencing.output.js
+++ b/packages/shopify-codemod/test/fixtures/global-reference-to-import/self-referencing.output.js
@@ -1,0 +1,11 @@
+'expose App.A';
+
+export default class A {
+  static b() {
+    A.c();
+  }
+
+  static c() {
+
+  }
+}

--- a/packages/shopify-codemod/test/fixtures/javascripts/app/components/self-referencing.js
+++ b/packages/shopify-codemod/test/fixtures/javascripts/app/components/self-referencing.js
@@ -1,0 +1,11 @@
+'expose App.A';
+
+export default class A {
+  static b() {
+    App.A.c();
+  }
+
+  static c() {
+
+  }
+}

--- a/packages/shopify-codemod/test/transforms/global-reference-to-import.test.js
+++ b/packages/shopify-codemod/test/transforms/global-reference-to-import.test.js
@@ -31,4 +31,8 @@ describe('globalReferenceToImport', () => {
   it('imports from a JavaScript file when there are multiple matches with comparable paths', () => {
     expect(globalReferenceToImport).to.transform('global-reference-to-import/multiple-matches/basic-valid');
   });
+
+  it('only renames globals that are present in the same file', () => {
+    expect(globalReferenceToImport).to.transform('global-reference-to-import/self-referencing');
+  });
 });


### PR DESCRIPTION
Fixes #99. Maybe fixes #95. This PR fixes files importing themselves by checking the `expose` directive (so, it must come after the default export transform, which it does), and adds a global cache that I believe will speed up the lookups between transforms.

cc/ @bouk @GoodForOneFare @fandy 