### PR TITLE
`catch (undefined)` => `catch (error)`

### DIFF
--- a/packages/shopify-codemod/test/fixtures/catch-undefined-to-catch-error/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/catch-undefined-to-catch-error/basic.input.js
@@ -1,0 +1,7 @@
+function foo() {
+  try {
+
+  } catch (undefined) {
+
+  }
+}

--- a/packages/shopify-codemod/test/fixtures/catch-undefined-to-catch-error/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/catch-undefined-to-catch-error/basic.output.js
@@ -1,0 +1,7 @@
+function foo() {
+  try {
+
+  } catch (error) {
+
+  }
+}

--- a/packages/shopify-codemod/test/fixtures/catch-undefined-to-catch-error/error-already-in-scope.input.js
+++ b/packages/shopify-codemod/test/fixtures/catch-undefined-to-catch-error/error-already-in-scope.input.js
@@ -1,0 +1,7 @@
+function foo() {
+  try {
+
+  } catch (undefined) {
+    console.log(error);
+  }
+}

--- a/packages/shopify-codemod/test/fixtures/catch-undefined-to-catch-error/error-already-in-scope.output.js
+++ b/packages/shopify-codemod/test/fixtures/catch-undefined-to-catch-error/error-already-in-scope.output.js
@@ -1,0 +1,7 @@
+function foo() {
+  try {
+
+  } catch (undefined) {
+    console.log(error);
+  }
+}

--- a/packages/shopify-codemod/test/transforms/catch-undefined-to-catch-error.test.js
+++ b/packages/shopify-codemod/test/transforms/catch-undefined-to-catch-error.test.js
@@ -1,0 +1,12 @@
+import 'test-helper';
+import transform from 'catch-undefined-to-catch-error';
+
+describe('catchUndefinedToCatchError', () => {
+  it('converts catch undefined to catch error', () => {
+    expect(transform).to.transform('catch-undefined-to-catch-error/basic');
+  });
+
+  it('does not convert catch undefined if error is already in scope', () => {
+    expect(transform).to.transform('catch-undefined-to-catch-error/error-already-in-scope');
+  });
+});

--- a/packages/shopify-codemod/transforms/catch-undefined-to-catch-error.js
+++ b/packages/shopify-codemod/transforms/catch-undefined-to-catch-error.js
@@ -1,0 +1,17 @@
+export default function catchUndefinedToCatchError({source}, {jscodeshift: j}, {printOptions = {quote: 'single'}}) {
+  function hasNoErrorReferences(path) {
+    const usage = j(path).find(j.Identifier, {name: 'error'});
+
+    return usage.size() === 0;
+  }
+
+  return j(source)
+    .find(j.CatchClause, {
+      param: {
+        name: 'undefined',
+      },
+    })
+    .filter(hasNoErrorReferences)
+    .forEach(({node: {param}}) => { param.name = 'error'; })
+    .toSource(printOptions);
+}


### PR DESCRIPTION
Decaf generates many of these :/  Note there's a task (#109) to remove empty `catch` blocks.  But that's a PR for another day :)

/cc @lemonmade, @fandy