### PR TITLE
Fix existential soak checks

### DIFF
--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
@@ -44,3 +44,9 @@ var foo = {
 var foo = {
   bar: (((typeof a !== 'undefined' && a !== null ? a.b : void 0)) != null ? a.b = c : undefined),
 };
+
+// @a = a if a?[bar]?()
+((typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) ? this.a = a : undefined);
+
+// @a = a if a?[bar]?()?
+((typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0) != null ? this.a = a : undefined);

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.input.js
@@ -36,4 +36,11 @@ if (!(typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a
 // foo = bar: !a?[bar]?()
 var foo = {
   bar: !(typeof a !== "undefined" && a !== null ? (typeof a[bar] === "function" ? a[bar]() : void 0) : void 0),
-}
+};
+
+// a.b = c if a?.b?
+(((typeof a !== 'undefined' && a !== null ? a.b : void 0)) != null ? a.b = c : undefined);
+
+var foo = {
+  bar: (((typeof a !== 'undefined' && a !== null ? a.b : void 0)) != null ? a.b = c : undefined),
+};

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
@@ -40,4 +40,12 @@ if (a == null || typeof a[bar] !== 'function' || !a[bar]()) {
 // foo = bar: !a?[bar]?()
 var foo = {
   bar: a == null || typeof a[bar] !== 'function' || !a[bar](),
+};
+
+if (a != null && a.b != null) {
+  a.b = c;
 }
+
+var foo = {
+  bar: ((a != null && a.b != null ? a.b = c : undefined)),
+};

--- a/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
+++ b/packages/shopify-codemod/test/fixtures/coffeescript-soak-to-condition/other-parents.output.js
@@ -49,3 +49,11 @@ if (a != null && a.b != null) {
 var foo = {
   bar: ((a != null && a.b != null ? a.b = c : undefined)),
 };
+
+if (a != null && typeof a[bar] === 'function' && a[bar]()) {
+  this.a = a;
+}
+
+if (a != null && typeof a[bar] === 'function' && a[bar]() != null) {
+  this.a = a;
+}

--- a/packages/shopify-codemod/transforms/coffeescript-soak-to-condition.js
+++ b/packages/shopify-codemod/transforms/coffeescript-soak-to-condition.js
@@ -4,7 +4,8 @@ export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, 
   function handleOffensiveConditional(path) {
     let memberExpression;
     let condition;
-    let currentConsequent = path;
+    const isNullCheckOfSoak = conditionalExpressionIsNullCheckOfSoak(path);
+    let currentConsequent = isNullCheckOfSoak ? path.get('test', 'left') : path;
 
     while (isOffensiveConditionalExpression(currentConsequent)) {
       const currentTest = currentConsequent.get('test');
@@ -25,6 +26,13 @@ export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, 
 
     const {node} = path;
     const finalValue = augmentMemberExpression(memberExpression, currentConsequent.value);
+    let finalExpression = isNullCheckOfSoak ? path.get('consequent').node : finalValue;
+
+    if (isNullCheckOfSoak) {
+      condition = j.logicalExpression('&&', condition, createLooseUndefinedCheck(finalValue));
+      finalExpression = path.get('consequent').node;
+    }
+
     const parentPath = path.parentPath;
     const parentNode = parentPath.node;
 
@@ -36,7 +44,7 @@ export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, 
             j.variableDeclaration('var', [
               j.variableDeclarator(
                 parentPath.get('id').value,
-                finalValue
+                finalExpression
               ),
             ]),
           ])
@@ -46,27 +54,27 @@ export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, 
       parentPath.replace(
         j.ifStatement(
           condition,
-          j.blockStatement([j.expressionStatement(finalValue)])
+          j.blockStatement([j.expressionStatement(finalExpression)])
         )
       );
     } else if (j.ReturnStatement.check(parentNode)) {
       parentPath.replace(
         j.ifStatement(
           condition,
-          j.blockStatement([j.returnStatement(finalValue)]),
+          j.blockStatement([j.returnStatement(finalExpression)]),
           j.blockStatement([j.returnStatement(j.literal(null))])
         )
       );
     } else if (isConditionalTest(parentNode)) {
       path.replace(
-        j.logicalExpression('&&', condition, finalValue)
+        j.logicalExpression('&&', condition, finalExpression)
       );
     } else if (j.BinaryExpression.check(parentNode) && hasDeterminableDefinedState(opposite(path).node)) {
       const matchesUndefined = isBinaryExpressionThatMatchesUndefined(parentNode);
 
       const isOnRight = (parentNode.right === node);
-      const leftArg = isOnRight ? parentNode.left : finalValue;
-      const rightArg = isOnRight ? finalValue : parentNode.right;
+      const leftArg = isOnRight ? parentNode.left : finalExpression;
+      const rightArg = isOnRight ? finalExpression : parentNode.right;
       const newBinaryExpression = j.binaryExpression(parentNode.operator, leftArg, rightArg);
 
       parentPath.replace(
@@ -78,11 +86,11 @@ export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, 
       );
     } else if (j.UnaryExpression.check(parentNode) && parentNode.operator === '!') {
       parentPath.replace(
-        j.logicalExpression('||', invertCondition(condition), j.unaryExpression('!', finalValue))
+        j.logicalExpression('||', invertCondition(condition), j.unaryExpression('!', finalExpression))
       );
     } else {
       path.replace(
-        j.conditionalExpression(condition, finalValue, j.identifier('undefined'))
+        j.conditionalExpression(condition, finalExpression, j.identifier('undefined'))
       );
     }
   }
@@ -264,6 +272,11 @@ export default function coffeescriptSoakToCondition({source}, {jscodeshift: j}, 
         right: isNull,
       },
     });
+  }
+
+  function conditionalExpressionIsNullCheckOfSoak(path) {
+    return j.match(path.node, {test: isLooseUndefinedCheck}) &&
+      isOffensiveConditionalExpression(path.get('test', 'left'));
   }
 
   function isOffensiveConditionalTest(node) {


### PR DESCRIPTION
Fixes #97. This PR updates `coffeescript-soak-to-condition` to understand an additional edge case with soak/ existential operators.

cc/ @GoodForOneFare @fandy 