### PR TITLE
Remove block statements for single-return arrow functions

### DIFF
--- a/packages/shopify-codemod/test/fixtures/function-to-arrow/bad-arrow.input.js
+++ b/packages/shopify-codemod/test/fixtures/function-to-arrow/bad-arrow.input.js
@@ -1,0 +1,8 @@
+const foo = () => {
+  return bar;
+};
+
+const baz = () => {
+  const qux = fuzz;
+  return qux;
+}

--- a/packages/shopify-codemod/test/fixtures/function-to-arrow/bad-arrow.output.js
+++ b/packages/shopify-codemod/test/fixtures/function-to-arrow/bad-arrow.output.js
@@ -1,0 +1,6 @@
+const foo = () => bar;
+
+const baz = () => {
+  const qux = fuzz;
+  return qux;
+}

--- a/packages/shopify-codemod/test/transforms/function-to-arrow.test.js
+++ b/packages/shopify-codemod/test/transforms/function-to-arrow.test.js
@@ -22,7 +22,7 @@ describe('functionToArrow', () => {
     expect(functionToArrow).to.transform('function-to-arrow/return-without-argument');
   });
 
-  it.only('transforms existing arrow functions with a single return to omit a block statement', () => {
+  it('transforms existing arrow functions with a single return to omit a block statement', () => {
     expect(functionToArrow).to.transform('function-to-arrow/bad-arrow');
   });
 });

--- a/packages/shopify-codemod/test/transforms/function-to-arrow.test.js
+++ b/packages/shopify-codemod/test/transforms/function-to-arrow.test.js
@@ -21,4 +21,8 @@ describe('functionToArrow', () => {
   it('transforms return without argument to empty arrow function', () => {
     expect(functionToArrow).to.transform('function-to-arrow/return-without-argument');
   });
+
+  it.only('transforms existing arrow functions with a single return to omit a block statement', () => {
+    expect(functionToArrow).to.transform('function-to-arrow/bad-arrow');
+  });
 });

--- a/packages/shopify-codemod/transforms/function-to-arrow.js
+++ b/packages/shopify-codemod/transforms/function-to-arrow.js
@@ -11,7 +11,19 @@ export default function functionToArrow({source}, {jscodeshift: j}, {printOption
     return !isMember(path) && !containsThisExpression(path);
   }
 
-  return j(source)
+  const root = j(source);
+
+  root
+    .find(j.ArrowFunctionExpression, {
+      body: {
+        body: [{type: j.ReturnStatement.name}],
+      },
+    })
+    .replaceWith(({node: {params, body: {body: [{argument}]}}}) => (
+      j.arrowFunctionExpression(params, argument, true)
+    ));
+
+  root
     .find(j.FunctionExpression)
     .filter(isConvertibleFunction)
     .replaceWith(({node}) => {
@@ -27,6 +39,7 @@ export default function functionToArrow({source}, {jscodeshift: j}, {printOption
         }
       }
       return j.arrowFunctionExpression(params, body, body.type !== 'BlockStatement');
-    })
-    .toSource(printOptions);
+    });
+
+  return root.toSource(printOptions);
 }

--- a/packages/shopify-codemod/transforms/function-to-arrow.js
+++ b/packages/shopify-codemod/transforms/function-to-arrow.js
@@ -11,9 +11,9 @@ export default function functionToArrow({source}, {jscodeshift: j}, {printOption
     return !isMember(path) && !containsThisExpression(path);
   }
 
-  const root = j(source);
+  const sourceAST = j(source);
 
-  root
+  sourceAST
     .find(j.ArrowFunctionExpression, {
       body: {
         body: [{type: j.ReturnStatement.name}],
@@ -23,7 +23,7 @@ export default function functionToArrow({source}, {jscodeshift: j}, {printOption
       j.arrowFunctionExpression(params, argument, true)
     ));
 
-  root
+  sourceAST
     .find(j.FunctionExpression)
     .filter(isConvertibleFunction)
     .replaceWith(({node}) => {
@@ -41,5 +41,5 @@ export default function functionToArrow({source}, {jscodeshift: j}, {printOption
       return j.arrowFunctionExpression(params, body, body.type !== 'BlockStatement');
     });
 
-  return root.toSource(printOptions);
+  return sourceAST.toSource(printOptions);
 }


### PR DESCRIPTION
This PR augments `function-to-arrow` to also remove block statements from existing single-return arrow functions, which are generated by other things and aren't currently being handled.