### PR TITLE
Add a computed-literal-keys-to-dot-notation transform

### DIFF
--- a/packages/esify/index.js
+++ b/packages/esify/index.js
@@ -38,6 +38,7 @@ var TRANSFORMS = [
   // These are run very late to ensure they catch any identifiers/ member expressions
   // added in earlier transforms
   {path: 'js-codemod/transforms/unquote-properties'},
+  {path: 'shopify-codemod/computed-literal-keys-to-dot-notation'},
   {path: 'shopify-codemod/transforms/rename-identifier'},
   {path: 'shopify-codemod/transforms/rename-property'},
   // constant-function-expression-to-statement and global-reference-to-import need

--- a/packages/shopify-codemod/README.md
+++ b/packages/shopify-codemod/README.md
@@ -12,6 +12,32 @@ This repository contains a collection of Codemods written with [JSCodeshift](htt
 
 ## Included Transforms
 
+### `computed-literal-keys-to-dot-notation`
+
+Transforms member expressions that have string literal keys to use dot notation whenever possible.
+
+```sh
+jscodeshift -t shopify-codemods/transforms/rename-identifier <file>
+```
+
+#### Example
+
+```js
+foo['bar']['baz'] = 'qux';
+this['_foo'] = 'bar';
+foo[0] = 42;
+foo['bar-baz'] = 'qux';
+foo[bar] = 'qux';
+
+// BECOMES:
+
+foo.bar.baz = 'qux';
+this._foo = 'bar';
+foo[0] = 42;
+foo['bar-baz'] = 'qux';
+foo[bar] = 'qux';
+```
+
 ### `rename-identifier`
 
 Renames a user-defined list of identifiers. Use the `renameIdentifiers` option to specify the old name/ new name pairs.

--- a/packages/shopify-codemod/test/fixtures/computed-literal-keys-to-dot-notation/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/computed-literal-keys-to-dot-notation/basic.input.js
@@ -1,0 +1,10 @@
+foo['bar'] = true;
+foo['bar']['baz'] = true;
+this['foo'] = true;
+foo[0] = false;
+foo['bar-baz'] = false;
+foo['_bar'] = true;
+foo['$bar'] = true;
+foo[bar] = false;
+foo['0'] = false;
+foo['Bar'] = true;

--- a/packages/shopify-codemod/test/fixtures/computed-literal-keys-to-dot-notation/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/computed-literal-keys-to-dot-notation/basic.output.js
@@ -1,0 +1,10 @@
+foo.bar = true;
+foo.bar.baz = true;
+this.foo = true;
+foo[0] = false;
+foo['bar-baz'] = false;
+foo._bar = true;
+foo.$bar = true;
+foo[bar] = false;
+foo['0'] = false;
+foo.Bar = true;

--- a/packages/shopify-codemod/test/fixtures/rename-property/invalid-identifier.input.js
+++ b/packages/shopify-codemod/test/fixtures/rename-property/invalid-identifier.input.js
@@ -1,0 +1,1 @@
+foo.bar = true;

--- a/packages/shopify-codemod/test/fixtures/rename-property/invalid-identifier.output.js
+++ b/packages/shopify-codemod/test/fixtures/rename-property/invalid-identifier.output.js
@@ -1,0 +1,1 @@
+foo['baz-qux'] = true;

--- a/packages/shopify-codemod/test/transforms/computed-literal-keys-to-dot-notation.test.js
+++ b/packages/shopify-codemod/test/transforms/computed-literal-keys-to-dot-notation.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import transform from 'computed-literal-keys-to-dot-notation';
+
+describe('computedLiteralKeysToDotNotation', () => {
+  it('transforms valid string computed keys to dot notation', () => {
+    expect(transform).to.transform('computed-literal-keys-to-dot-notation/basic');
+  });
+});

--- a/packages/shopify-codemod/test/transforms/rename-property.test.js
+++ b/packages/shopify-codemod/test/transforms/rename-property.test.js
@@ -12,4 +12,10 @@ describe('renameProperty', () => {
       },
     });
   });
+
+  it('transforms invalid identifier names to string literal computed keys', () => {
+    expect(transform).to.transform('rename-property/invalid-identifier', {
+      renameProperties: {foo: {bar: 'baz-qux'}},
+    });
+  });
 });

--- a/packages/shopify-codemod/transforms/computed-literal-keys-to-dot-notation.js
+++ b/packages/shopify-codemod/transforms/computed-literal-keys-to-dot-notation.js
@@ -1,0 +1,18 @@
+import {isValidIdentifier} from './utils';
+
+export default function computedLiteralKeysToDotNotation({source}, {jscodeshift: j}, {printOptions = {quote: 'single'}}) {
+
+  return j(source)
+    .find(j.MemberExpression, {
+      property: {
+        type: j.Literal.name,
+        value: isValidIdentifier,
+      },
+    })
+    .forEach((path) => {
+      const {node: {property: {value}}} = path;
+      path.get('computed').replace(false);
+      path.get('property').replace(j.identifier(value));
+    })
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/rename-property.js
+++ b/packages/shopify-codemod/transforms/rename-property.js
@@ -1,4 +1,4 @@
-import {pathIsFirstMember} from './utils';
+import {pathIsFirstMember, isValidIdentifier} from './utils';
 
 export default function renameProperty({source}, {jscodeshift: j}, {printOptions = {quote: 'single'}, renameProperties = {}}) {
   function hasPropertyThatShouldBeRenamed({node: {computed, object, property}}) {
@@ -12,7 +12,12 @@ export default function renameProperty({source}, {jscodeshift: j}, {printOptions
     .filter((path) => pathIsFirstMember(path) && hasPropertyThatShouldBeRenamed(path))
     .forEach((path) => {
       const {node: {object, property}} = path;
-      path.get('property').replace(j.identifier(renameProperties[object.name][property.name]));
+      const newName = renameProperties[object.name][property.name];
+      const newNameIsValidIdentifier = isValidIdentifier(newName);
+      path.get('property').replace(
+        newNameIsValidIdentifier ? j.identifier(newName) : j.literal(newName)
+      );
+      path.get('computed').replace(!newNameIsValidIdentifier);
     })
     .toSource(printOptions);
 }

--- a/packages/shopify-codemod/transforms/utils.js
+++ b/packages/shopify-codemod/transforms/utils.js
@@ -44,6 +44,12 @@ export function pathIsFirstMember({node, parentPath: {node: parentNode}}) {
   return !j.MemberExpression.check(parentNode) || parentNode.object === node;
 }
 
+const IDENTIFIER_REGEX = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
+export function isValidIdentifier(identifier) {
+  return typeof identifier === 'string' && IDENTIFIER_REGEX.test(identifier);
+}
+
 // from https://github.com/sindresorhus/globals/blob/1e9ebc39828b92bd5c8ec7dc7bb07d62f2fb0153/globals.json#L852
 export const MOCHA_FUNCTIONS = new Set([
   'after',


### PR DESCRIPTION
Fixes #111. This PR cleans up string literal keys that are valid identifiers to use dot notation for member expressions. Also fixed a potential bug in rename-property for renaming a property to a name that is not a valid identifier (unlikely, but whatever, may as well check).

cc/ @GoodForOneFare @fandy 