### PR TITLE
Fix jQuery reference edge cases

### DIFF
--- a/packages/eslint-plugin-shopify/lib/rules/jquery-dollar-sign-reference.js
+++ b/packages/eslint-plugin-shopify/lib/rules/jquery-dollar-sign-reference.js
@@ -63,12 +63,30 @@ module.exports = function(context) {
     return node.type === 'CallExpression';
   }
 
-  function isjQueryStartValue(node) {
-    return (node.type === 'Identifier' && isjQueryReference(node)) || isjQueryCallExpression(node);
+  function isjQueryTerminatedMemberExpression(node) {
+    return node.type === 'MemberExpression' && (
+      (node.computed && node.property.type === 'Literal' && isjQueryReference(node.property)) ||
+      (!node.computed && isjQueryReference(node.property))
+    );
   }
 
-  function isNull(node) {
-    return (node.type === 'Literal' && node.value === null);
+  function isMemberExpressionWithComputedNonLiteralProperty(node) {
+    return node.type === 'MemberExpression' && node.computed && node.property.type !== 'Literal';
+  }
+
+  function isjQueryStartValue(node) {
+    return (
+      (node.type === 'Identifier' && isjQueryReference(node)) ||
+      isjQueryCallExpression(node) ||
+      isjQueryTerminatedMemberExpression(node)
+    );
+  }
+
+  function isLooseUndefined(node) {
+    return (
+      (node.type === 'Identifier' && node.name === 'undefined') ||
+      (node.type === 'Literal' && node.value === null)
+    );
   }
 
   function isjQueryValue(node) {
@@ -89,9 +107,17 @@ module.exports = function(context) {
 
     var isjQueryStart = isjQueryStartValue(relevantNode);
     var definiteNo = isjQueryStart && !validChain;
+    var definiteYes = isjQueryStart && validChain;
     return {
-      definite: isjQueryStart && validChain,
-      possible: !definiteNo && (isNull(node) || (isjQueryStart && node.type === 'Identifier') || isCallExpression(node)),
+      definite: definiteYes,
+      possible: definiteYes || (
+        !definiteNo && (
+          isLooseUndefined(node) ||
+          (isjQueryStart && node.type === 'Identifier') ||
+          isCallExpression(node) ||
+          isMemberExpressionWithComputedNonLiteralProperty(node)
+        )
+      ),
     };
   }
 
@@ -99,6 +125,7 @@ module.exports = function(context) {
     if (right == null) { return; }
     var isjQueryRef = isjQueryReference(left);
     var isjQueryVal = isjQueryValue(right);
+    // console.log(right);
 
     if (isjQueryRef && !isjQueryVal.possible) {
       context.report(node, 'Don’t use a $-prefixed identifier for a non-jQuery value.');
@@ -107,16 +134,26 @@ module.exports = function(context) {
     }
   }
 
+  function getFinalAssignmentValue(node) {
+    var currentNode = node;
+
+    while (currentNode && currentNode.type === 'AssignmentExpression') {
+      currentNode = currentNode.right;
+    }
+
+    return currentNode;
+  }
+
   function checkVariableDeclarator(node) {
-    checkForValidjQueryReference(node, node.id, node.init);
+    checkForValidjQueryReference(node, node.id, getFinalAssignmentValue(node.init));
   }
 
   function checkAssignmentExpression(node) {
-    if (node.left.type === 'MemberExpression' && node.left.computed && node.left.property.type !== 'Literal') {
+    if (isMemberExpressionWithComputedNonLiteralProperty(node.left)) {
       return;
     }
 
-    checkForValidjQueryReference(node, node.left, node.right);
+    checkForValidjQueryReference(node, node.left, getFinalAssignmentValue(node.right));
   }
 
   function checkObjectExpression(node) {

--- a/packages/eslint-plugin-shopify/tests/lib/rules/jquery-dollar-sign-reference.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/jquery-dollar-sign-reference.js
@@ -203,6 +203,26 @@ ruleTester.run('jquery-dollar-sign-reference', rule, {
     {code: 'var foo = $bar.triggerHandler();'},
     {code: 'var foo = $bar.val();'},
     {code: 'var foo = $bar.width();'},
+
+    {code: 'var foo = {$bar: null};'},
+    {code: 'var foo = {bar: null};'},
+
+    {code: 'var $foo = bar = $baz = null;'},
+    {code: 'var $foo; $foo = bar = $baz = undefined;'},
+
+    {code: 'var $foo = foo.$bar;'},
+    {code: 'var $foo = foo.$bar.attr({});'},
+    {code: 'var foo = foo.bar.attr({});'},
+    {code: 'var foo = foo.$bar.size();'},
+
+    {code: 'var $foo = foo["$foo"];'},
+    {code: 'var $foo = foo["$foo"].attr({});'},
+    {code: 'var foo = foo["bar"].attr({});'},
+    {code: 'var foo = foo["$foo"].size();'},
+    {code: 'var foo = foo[$foo];'},
+    {code: 'var $foo = foo[$foo];'},
+    {code: 'var foo = foo[bar];'},
+    {code: 'var $foo = foo[bar];'},
   ],
   invalid: [
     {
@@ -525,6 +545,33 @@ ruleTester.run('jquery-dollar-sign-reference', rule, {
     },
     {
       code: 'var $foo = $bar.width();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+
+    {
+      code: 'var $foo = bar = $baz;',
+      errors: [missingDollarError({type: 'AssignmentExpression'})],
+    },
+
+    {
+      code: 'var foo = foo.$bar;',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = foo.$bar.attr({});',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = foo.$bar.size();',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+
+    {
+      code: 'var foo = foo["$foo"];',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = foo["$foo"].size();',
       errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
     },
   ],


### PR DESCRIPTION
This PR fixes #106. It handles a couple extra edge cases for jQuery reference detection, including jQuery-looking keys of objects and multi-assignments.

cc/ @fandy 