### PR TITLE
Added IIFE to Ternary transform

### DIFF
--- a/packages/esify/lib/codemod.js
+++ b/packages/esify/lib/codemod.js
@@ -40,6 +40,7 @@ var TRANSFORMS = [
   {path: 'js-codemod/transforms/template-literals'},
   {path: 'shopify-codemod/transforms/strip-template-literal-parenthesis'},
   {path: 'js-codemod/transforms/object-shorthand'},
+  {path: 'shopify-codemod/transforms/iife-to-ternary-expression'},
   // These are run very late to ensure they catch any identifiers/ member expressions
   // added in earlier transforms
   {path: 'js-codemod/transforms/unquote-properties'},

--- a/packages/shopify-codemod/docs/iife-to-ternary-expression.md
+++ b/packages/shopify-codemod/docs/iife-to-ternary-expression.md
@@ -1,0 +1,23 @@
+### `iife-to-ternary-expression`
+
+Replaces Decaf generated IIFEs containing if-else statements with ternaries.
+
+```sh
+jscodeshift -t shopify-codemod/transforms/iife-to-ternary-expression <file>
+```
+
+#### Example
+
+```js
+let foo = (() => {
+  if (test) {
+    return bar;
+  } else {
+    return baz;
+  }
+})();
+
+// BECOMES:
+
+let foo = (test ? bar : baz);
+```

--- a/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/basic.input.js
@@ -1,0 +1,36 @@
+(() => {
+  if (pass) {
+    return bar;
+  } else {
+    return baz;
+  }
+})();
+
+(() => {
+  if (multilineConsequent) {
+    bar = 34;
+    return bar;
+  } else {
+    return baz;
+  }
+})();
+
+(() => {
+  if (multilineAlternate) {
+    return bar;
+  } else {
+    baz = 34;
+    return baz;
+  }
+})();
+
+(() => {
+  moreThanJustAnIfStatement()
+  if (fail) {
+    return bar;
+  } else {
+    return baz;
+  }
+})();
+
+someFunction();

--- a/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/basic.input.js
@@ -6,6 +6,22 @@
   }
 })();
 
+(function () {
+  if (pass) {
+    return bar;
+  } else {
+    return baz;
+  }
+})();
+
+((arg) => {
+  if (pass) {
+    return arg;
+  } else {
+    return baz;
+  }
+})(param);
+
 (() => {
   if (multilineConsequent) {
     bar = 34;

--- a/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/basic.output.js
@@ -1,5 +1,15 @@
 (pass ? bar : baz);
 
+(pass ? bar : baz);
+
+((arg) => {
+  if (pass) {
+    return arg;
+  } else {
+    return baz;
+  }
+})(param);
+
 (() => {
   if (multilineConsequent) {
     bar = 34;

--- a/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/basic.output.js
@@ -1,0 +1,30 @@
+(pass ? bar : baz);
+
+(() => {
+  if (multilineConsequent) {
+    bar = 34;
+    return bar;
+  } else {
+    return baz;
+  }
+})();
+
+(() => {
+  if (multilineAlternate) {
+    return bar;
+  } else {
+    baz = 34;
+    return baz;
+  }
+})();
+
+(() => {
+  moreThanJustAnIfStatement()
+  if (fail) {
+    return bar;
+  } else {
+    return baz;
+  }
+})();
+
+someFunction();

--- a/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/sanity.input.js
+++ b/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/sanity.input.js
@@ -1,0 +1,27 @@
+function foo() {
+  return (() => {
+    if (pass) {
+      return bar;
+    } else {
+      return baz;
+    }
+  })();
+}
+
+const foo = (() => {
+  if (pass) {
+    return bar;
+  } else {
+    return baz;
+  }
+})();
+
+const boo = {
+  foo: (() => {
+    if (pass) {
+      return bar;
+    } else {
+      return baz;
+    }
+  })()
+};

--- a/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/sanity.output.js
+++ b/packages/shopify-codemod/test/fixtures/iife-to-ternary-expression/sanity.output.js
@@ -1,0 +1,9 @@
+function foo() {
+  return (pass ? bar : baz);
+}
+
+const foo = (pass ? bar : baz);
+
+const boo = {
+  foo: (pass ? bar : baz)
+};

--- a/packages/shopify-codemod/test/transforms/iife-to-ternary-expression.test.js
+++ b/packages/shopify-codemod/test/transforms/iife-to-ternary-expression.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import transform from 'iife-to-ternary-expression';
+
+describe('iifeToTernaryExpression', () => {
+  it('replaces Decaf generated IIFEs containing ternaries with original ternaries', () => {
+    expect(transform).to.transform('iife-to-ternary-expression/basic', {});
+  });
+});

--- a/packages/shopify-codemod/test/transforms/iife-to-ternary-expression.test.js
+++ b/packages/shopify-codemod/test/transforms/iife-to-ternary-expression.test.js
@@ -2,7 +2,10 @@ import 'test-helper';
 import transform from 'iife-to-ternary-expression';
 
 describe('iifeToTernaryExpression', () => {
-  it('replaces Decaf generated IIFEs containing ternaries with original ternaries', () => {
+  it('does not replace IIFEs that do not contain if-else statements representing ternaries', () => {
     expect(transform).to.transform('iife-to-ternary-expression/basic', {});
+  });
+  it('replaces IIFEs that are used in assignment and return statements', () => {
+    expect(transform).to.transform('iife-to-ternary-expression/sanity', {});
   });
 });

--- a/packages/shopify-codemod/transforms/iife-to-ternary-expression.js
+++ b/packages/shopify-codemod/transforms/iife-to-ternary-expression.js
@@ -1,7 +1,7 @@
 export default function iifeToTernaryExpression({source}, {jscodeshift: j}, {printOptions = {}}) {
   function isImmediatelyInvokedFunctionExpression(expressionPath) {
     let expression = expressionPath.node.expression
-    return expression.type == 'CallExpression' && expression.callee.type == 'ArrowFunctionExpression'
+    return expression.type === 'CallExpression' && expression.callee.type === 'ArrowFunctionExpression'
   }
 
   function containsOnlyIfStatement(functionNode) {
@@ -14,9 +14,9 @@ export default function iifeToTernaryExpression({source}, {jscodeshift: j}, {pri
   }
 
   function nodeIsBlockStatementContainingOnly(node, childType) {
-    return node.type == 'BlockStatement' &&
-           node.body.length == 1 &&
-         node.body[0].type == childType;
+    return node.type === 'BlockStatement' &&
+           node.body.length === 1 &&
+         node.body[0].type === childType;
   }
 
   function isConvertibleExpression(path) {

--- a/packages/shopify-codemod/transforms/iife-to-ternary-expression.js
+++ b/packages/shopify-codemod/transforms/iife-to-ternary-expression.js
@@ -1,0 +1,48 @@
+export default function iifeToTernaryExpression({source}, {jscodeshift: j}, {printOptions = {}}) {
+  function isImmediatelyInvokedFunctionExpression(expressionPath) {
+    let expression = expressionPath.node.expression
+    return expression.type == 'CallExpression' && expression.callee.type == 'ArrowFunctionExpression'
+  }
+
+  function containsOnlyIfStatement(functionNode) {
+    return nodeIsBlockStatementContainingOnly(functionNode.body, 'IfStatement');
+  }
+
+  function onlyReturnsOneOfTwoValues(ifStatementNode) {
+    return nodeIsBlockStatementContainingOnly(ifStatementNode.consequent, 'ReturnStatement') &&
+           nodeIsBlockStatementContainingOnly(ifStatementNode.alternate, 'ReturnStatement');
+  }
+
+  function nodeIsBlockStatementContainingOnly(node, childType) {
+    return node.type == 'BlockStatement' &&
+           node.body.length == 1 &&
+         node.body[0].type == childType;
+  }
+
+  function isConvertibleExpression(path) {
+    return isImmediatelyInvokedFunctionExpression(path) &&
+           containsOnlyIfStatement(path.node.expression.callee) &&
+           onlyReturnsOneOfTwoValues(path.node.expression.callee.body.body[0]);
+  }
+
+  const sourceAST = j(source);
+
+  sourceAST
+    .find(j.ExpressionStatement)
+    .filter(isConvertibleExpression)
+    .replaceWith(({node}) => {
+      let {expression: {callee: {body: functionBlockStatement}}} = node;
+    let {body: [{test,
+                   consequent: {body: [{argument: consequentIdentifier}]},
+                   alternate: {body: [{argument: alternateIdentifier}]}
+                  }]} = functionBlockStatement;
+
+      let ternaryExpression = j.conditionalExpression(test, consequentIdentifier, alternateIdentifier);
+      let newFunctionBlockStatement = j.blockStatement([j.expressionStatement(ternaryExpression)]);
+      let newArrowFunction = j.arrowFunctionExpression([], newFunctionBlockStatement, true);
+
+      return j.expressionStatement(j.callExpression(newArrowFunction, []));
+    });
+
+  return sourceAST.toSource(printOptions);
+}


### PR DESCRIPTION
https://github.com/Shopify/javascript/issues/158

Turns:
```js
(() => {
  if (foo) {
    return bar;
  } else {
    return baz;
  }
})();
```

into

```js
(() => {
  (foo ? bar : baz);
})();
```

~~If there a way I can just modify the body of a `Node` and then return the original `node`?~~
~~When I try~~
```js
let ternaryExpression = j.conditionalExpression(test, consequentIdentifier, alternateIdentifier);
functionBlockStatement.body = [ternaryExpression];

return node;
```
~~I get this error:~~
```
{test: [object Object], consequent: [object Object], alternate: [object Object], loc: null, type: ConditionalExpression, comments: null} does not match type string
```

~~Also should I be using destructuring assignments for the initial search of nodes?~~

@lemonmade @fandy @GoodForOneFare 