### PR TITLE
Removes pointless returns from specified methods

### DIFF
--- a/packages/shopify-codemod/test/fixtures/remove-pointless-returns-from-methods/lodash.input.js
+++ b/packages/shopify-codemod/test/fixtures/remove-pointless-returns-from-methods/lodash.input.js
@@ -1,0 +1,20 @@
+_.each(foo, (element, index) => {
+  if (index === 0) {
+    return;
+  }
+  return element.position = index;
+});
+
+_.filter(foo, (element, index) => {
+  if (index === 0) {
+    return;
+  }
+  return element.position = index;
+});
+
+_.doNotRemove(foo, (element, index) => {
+  if (index === 0) {
+    return;
+  }
+  return element.position = index;
+});

--- a/packages/shopify-codemod/test/fixtures/remove-pointless-returns-from-methods/lodash.output.js
+++ b/packages/shopify-codemod/test/fixtures/remove-pointless-returns-from-methods/lodash.output.js
@@ -1,0 +1,20 @@
+_.each(foo, (element, index) => {
+  if (index === 0) {
+    return;
+  }
+  element.position = index;
+});
+
+_.filter(foo, (element, index) => {
+  if (index === 0) {
+    return;
+  }
+  element.position = index;
+});
+
+_.doNotRemove(foo, (element, index) => {
+  if (index === 0) {
+    return;
+  }
+  return element.position = index;
+});

--- a/packages/shopify-codemod/test/transforms/remove-pointless-returns-from-methods.test.js
+++ b/packages/shopify-codemod/test/transforms/remove-pointless-returns-from-methods.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import removePointlessReturnsFromMethods from 'remove-pointless-returns-from-methods';
+
+describe('removePointlessReturnsFromMethods', () => {
+  it('removes pointless returns from lodash methods only', () => {
+    expect(removePointlessReturnsFromMethods).to.transform('remove-pointless-returns-from-methods/lodash');
+  });
+});

--- a/packages/shopify-codemod/transforms/remove-pointless-returns-from-methods.js
+++ b/packages/shopify-codemod/transforms/remove-pointless-returns-from-methods.js
@@ -1,0 +1,17 @@
+export default function removePointlessReturnsFromMethods({source}, {jscodeshift: j}, {printOptions = {}}) {
+  const sourceAST = j(source);
+  const POINTLESS_RETURN_METHODS = {
+    _: new Set(['each', 'filter']),
+  };
+  sourceAST
+    .find(j.CallExpression)
+    .filter(({node: {callee}}) => POINTLESS_RETURN_METHODS[callee.object.name].has(callee.property.name))
+    .forEach((nodePath) => {
+      const body = nodePath.node.arguments.filter((arg) => j.Function.check(arg))[0].body.body;
+      const returnLine = body.pop();
+      body.push(j.expressionStatement(returnLine.argument));
+    });
+
+  return sourceAST
+    .toSource(printOptions);
+}


### PR DESCRIPTION
This transform will remove returns in some methods that ignore return values (https://github.com/Shopify/javascript/issues/116).

Docs will be added when https://github.com/Shopify/javascript/pull/168 is merged.

/cc @lemonmade @GoodForOneFare @justinthec 