### PR TITLE
Allow prototype assignments to exported global

### DIFF
--- a/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/fails-on-global-assign-via-array-accessor.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/fails-on-global-assign-via-array-accessor.input.js
@@ -1,0 +1,3 @@
+App.A = class A {
+}
+App['A'] = 'yes';

--- a/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-non-prototype-assignment.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-non-prototype-assignment.input.js
@@ -1,5 +1,0 @@
-App.A = class A {
-
-};
-
-App.A.foo = () => {};

--- a/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-non-prototype-assignment.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-non-prototype-assignment.input.js
@@ -1,0 +1,5 @@
+App.A = class A {
+
+};
+
+App.A.foo = () => {};

--- a/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.input.js
@@ -1,0 +1,5 @@
+App.A = class A {
+
+};
+
+App.A.prototype.foo = () => {};

--- a/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.input.js
@@ -3,3 +3,6 @@ App.A = class A {
 };
 
 App.A.prototype.foo = () => {};
+App.A.bar.car = foo.bar || {};
+App.A.bar.qux = 'qux';
+App.A.qux = () => {};

--- a/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.input.js
@@ -6,3 +6,4 @@ App.A.prototype.foo = () => {};
 App.A.bar.car = foo.bar || {};
 App.A.bar.qux = 'qux';
 App.A.qux = () => {};
+App.A.buzz+= 10;

--- a/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.output.js
+++ b/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.output.js
@@ -5,3 +5,6 @@ export default class A {
 };
 
 A.prototype.foo = () => {};
+A.bar.car = foo.bar || {};
+A.bar.qux = 'qux';
+A.qux = () => {};

--- a/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.output.js
+++ b/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.output.js
@@ -1,0 +1,7 @@
+'expose App.A';
+
+export default class A {
+
+};
+
+A.prototype.foo = () => {};

--- a/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.output.js
+++ b/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/local-prototype-assignment.output.js
@@ -8,3 +8,4 @@ A.prototype.foo = () => {};
 A.bar.car = foo.bar || {};
 A.bar.qux = 'qux';
 A.qux = () => {};
+App.A.buzz+= 10;

--- a/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/prevent-multiple-exports.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-assignment-to-default-export/prevent-multiple-exports.input.js
@@ -1,0 +1,2 @@
+App.foo = class Foo {};
+App.bar = 'bar';

--- a/packages/shopify-codemod/test/transforms/global-assignment-to-default-export.test.js
+++ b/packages/shopify-codemod/test/transforms/global-assignment-to-default-export.test.js
@@ -22,9 +22,9 @@ describe('globalAssignmentToDefaultExport', () => {
     expect(globalAssignmentToDefaultExport).to.transform('global-assignment-to-default-export/local-prototype-assignment');
   });
 
-  it('prevents local non-prototype assignments', () => {
+  it('prevents multiple exports', () => {
     expect(globalAssignmentToDefaultExport).to.throwWhileTransforming(
-      'global-assignment-to-default-export/local-non-prototype-assignment',
+      'global-assignment-to-default-export/prevent-multiple-exports',
       /Found multiple exports in a single file/
     );
   });

--- a/packages/shopify-codemod/test/transforms/global-assignment-to-default-export.test.js
+++ b/packages/shopify-codemod/test/transforms/global-assignment-to-default-export.test.js
@@ -28,4 +28,11 @@ describe('globalAssignmentToDefaultExport', () => {
       /Found multiple exports in a single file/
     );
   });
+
+  it('fails on assignments via array accessors', () => {
+    expect(globalAssignmentToDefaultExport).to.throwWhileTransforming(
+      'global-assignment-to-default-export/fails-on-global-assign-via-array-accessor',
+      /Found multiple exports in a single file/
+    );
+  });
 });

--- a/packages/shopify-codemod/test/transforms/global-assignment-to-default-export.test.js
+++ b/packages/shopify-codemod/test/transforms/global-assignment-to-default-export.test.js
@@ -17,4 +17,15 @@ describe('globalAssignmentToDefaultExport', () => {
   it('preserves directives', () => {
     expect(globalAssignmentToDefaultExport).to.transform('global-assignment-to-default-export/directive');
   });
+
+  it('allows local prototype assignments', () => {
+    expect(globalAssignmentToDefaultExport).to.transform('global-assignment-to-default-export/local-prototype-assignment');
+  });
+
+  it('prevents local non-prototype assignments', () => {
+    expect(globalAssignmentToDefaultExport).to.throwWhileTransforming(
+      'global-assignment-to-default-export/local-non-prototype-assignment',
+      /Found multiple exports in a single file/
+    );
+  });
 });

--- a/packages/shopify-codemod/transforms/global-assignment-to-default-export.js
+++ b/packages/shopify-codemod/transforms/global-assignment-to-default-export.js
@@ -2,15 +2,11 @@ import {findFirstMember, insertAfterDirectives} from './utils';
 
 export default function globalAssignmentToDefaultExport({source}, {jscodeshift: j}, {printOptions = {}, appGlobalIdentifiers}) {
   function removeFirstMember(memberExpression) {
-    const members = j(memberExpression)
-      .find(j.MemberExpression)
-      .nodes()
-      .slice(-2);
-
-    const last = members.pop();
-    const parent = members.pop() || memberExpression;
-
-    parent.object = last.property;
+    j(memberExpression)
+      .find(j.MemberExpression, {
+        object: (node) => !j.MemberExpression.check(node),
+      })
+      .forEach((path) => path.replace(path.node.property));
 
     return memberExpression;
   }

--- a/packages/shopify-codemod/transforms/global-assignment-to-default-export.js
+++ b/packages/shopify-codemod/transforms/global-assignment-to-default-export.js
@@ -29,10 +29,25 @@ export default function globalAssignmentToDefaultExport({source}, {jscodeshift: 
 
           if (expose == null) {
             expose = j(member).toSource();
+            return j.exportDefaultDeclaration(statement);
           } else {
-            throw new Error('Found multiple exports in a single file, please break up the file first');
+            const newExpose = j(member).toSource();
+            if (newExpose.indexOf(`${expose}.prototype.`) !== 0) {
+              throw new Error('Found multiple exports in a single file, please break up the file first');
+            }
+
+            const {left, right} = path.node.expression;
+            return j.expressionStatement(
+              j.assignmentExpression(
+                '=',
+                j.memberExpression(
+                  j.memberExpression(left.object.object.property, left.object.property),
+                  left.property
+                ),
+                right
+              )
+            );
           }
-          return j.exportDefaultDeclaration(statement);
         });
 
       if (expose != null) {

--- a/packages/shopify-codemod/transforms/global-assignment-to-default-export.js
+++ b/packages/shopify-codemod/transforms/global-assignment-to-default-export.js
@@ -32,14 +32,8 @@ export default function globalAssignmentToDefaultExport({source}, {jscodeshift: 
           },
         })
         .replaceWith((path) => {
-          const {
-            node: {
-              expression: {
-                left: member,
-                right: statement,
-              },
-            },
-          } = path;
+          const expression = path.node.expression;
+          const {left: member, right: statement} = expression;
 
           if (expose == null) {
             expose = j(member).toSource();
@@ -55,7 +49,7 @@ export default function globalAssignmentToDefaultExport({source}, {jscodeshift: 
 
             return j.expressionStatement(
               j.assignmentExpression(
-                '=',
+                expression.operator,
                 removeFirstMember(left),
                 right
               )


### PR DESCRIPTION
If `App.Foo = class Foo` is defined, allows in-module assignments to `App.Foo.prototype`.

This clears up the lion's share of `Found multiple exports in a single file, please break up the file first` errors during `esify` (I'll raise a separate issue once I've analyzed the remainder).

It my be possible to fix this in decaf, but I'm putting out this PR because it's already written, and decaf may not fix things 100%.

/cc @lemonmade, @fandy, @justinthec