### PR TITLE
Add transforms for killing unecessary returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Added a `avoid-returning-unused-results` transform to remove return statement arguments from callbacks that are known to be ignored by the callee.
+- Added a `avoid-returning-useless-expressions` transform to remove return statement arguments that are known to return `undefined`.
+- Added a `remove-unused-expressions` transform to remove any expression without side effects.
 
+### Fixed
+- Fixes the method for running ESLint so it does not spawn a new process for each file.
 
 ## [12.2.0] - 2016-06-02
 ### Added

--- a/packages/esify/README.md
+++ b/packages/esify/README.md
@@ -81,5 +81,44 @@ module.exports = {
       extendWith: 'assignInWith',
     },
   },
+  // A list of object/ property pairs that always ignore return values of any
+  // callbacks passed to them
+  methodsThatIgnoreReturnValues: [
+    {
+      object: '_',
+      methods: ['each'],
+    },
+    {
+      object: /.*/,
+      methods: ['forEach'],
+    },
+  ],
+  // A list of object/ property pairs that always return undefined when called
+  methodsReturningVoid: [
+    {
+      object: 'console',
+      methods: ['log', 'warn'],
+    },
+    {
+      object: /^(e|evt|event)$/,
+      methods: ['preventDefault'],
+    },
+    {
+      object: 'console',
+      methods: ['log', 'warn'],
+    },
+    {
+      object: /^(e|evt|event)$/,
+      methods: ['preventDefault'],
+    },
+    {
+      object: /.*/,
+      methods: ['forEach'],
+    },
+    {
+      object: '_',
+      methods: ['each'],
+    },
+  ],
 }
 ```

--- a/packages/esify/README.md
+++ b/packages/esify/README.md
@@ -104,14 +104,6 @@ module.exports = {
       methods: ['preventDefault'],
     },
     {
-      object: 'console',
-      methods: ['log', 'warn'],
-    },
-    {
-      object: /^(e|evt|event)$/,
-      methods: ['preventDefault'],
-    },
-    {
       object: /.*/,
       methods: ['forEach'],
     },

--- a/packages/esify/lib/codemod.js
+++ b/packages/esify/lib/codemod.js
@@ -31,9 +31,12 @@ var TRANSFORMS = [
   {path: 'shopify-codemod/transforms/assert/called-method-to-assert-called', test: true},
   {path: 'shopify-codemod/transforms/assert/called-with-methods-to-assert-called-with', test: true},
   {path: 'shopify-codemod/transforms/assert/falsy-called-method-to-assert-not-called', test: true},
+  // These transforms must appear before remove-empty-returns and remove-unused-expressions
+  {path: 'shopify-codemod/transforms/remove-trailing-else-undefined-return'},
+  {path: 'shopify-codemod/transforms/avoid-returning-unused-results'},
+  {path: 'shopify-codemod/transforms/avoid-returning-useless-expressions'},
   // These are more generic, stylistic transforms, so they should come last to catch any
   // new nodes introduced by other transforms
-  {path: 'shopify-codemod/transforms/remove-trailing-else-undefined-return'},
   {path: 'shopify-codemod/transforms/remove-empty-returns'},
   {path: 'shopify-codemod/transforms/function-to-arrow'},
   {path: 'js-codemod/transforms/arrow-function'},
@@ -54,6 +57,7 @@ var TRANSFORMS = [
   {path: 'shopify-codemod/transforms/global-identifier-to-import'},
   // Must appear after constant-function-expression-to-statement in order to remove
   // unneeded semicolons from exported function declarations
+  {path: 'shopify-codemod/transforms/remove-unused-expressions'},
   {path: 'shopify-codemod/transforms/remove-empty-statements'},
 ];
 

--- a/packages/esify/lib/config.js
+++ b/packages/esify/lib/config.js
@@ -50,6 +50,34 @@ module.exports = function loadConfig() {
           extendWith: 'assignInWith',
         },
       },
+      methodsThatIgnoreReturnValues: [
+        {
+          object: '_',
+          methods: ['each'],
+        },
+        {
+          object: /.*/,
+          methods: ['forEach'],
+        },
+      ],
+      methodsReturningVoid: [
+        {
+          object: 'console',
+          methods: ['log', 'warn'],
+        },
+        {
+          object: /^(e|evt|event)$/,
+          methods: ['preventDefault'],
+        },
+        {
+          object: /.*/,
+          methods: ['forEach'],
+        },
+        {
+          object: '_',
+          methods: ['each'],
+        },
+      ],
     };
   }
 };

--- a/packages/shopify-codemod/README.md
+++ b/packages/shopify-codemod/README.md
@@ -12,7 +12,7 @@ This repository contains a collection of Codemods written with [JSCodeshift](htt
 
 ## Documentation
 
-[The documentation for each transform can be found in the docs folder](docs)
+The documentation for each transform can be found in the [docs folder](docs).
 
 ## Contributing
 

--- a/packages/shopify-codemod/docs/avoid-returning-unused-resuls.md
+++ b/packages/shopify-codemod/docs/avoid-returning-unused-resuls.md
@@ -1,0 +1,23 @@
+### `avoid-returning-unused-results`
+
+Removes return values from callbacks passed to functions that are known to ignore the return result. The list of methods that ignore the result is configurable using the `methodsThatIgnoreReturnValues` option.
+
+```sh
+jscodeshift -t shopify-codemods/transforms/avoid-returning-unused-results <file>
+```
+
+#### Example
+
+```js
+// using methodsThatIgnoreReturnValues: [{object: '_', methods: ['each']}]
+_.each(foo, () => {
+  return foo.bar();
+});
+
+// BECOMES
+
+_.each(foo, () => {
+  foo.bar();
+  return;
+});
+```

--- a/packages/shopify-codemod/docs/avoid-returning-useless-expressions.md
+++ b/packages/shopify-codemod/docs/avoid-returning-useless-expressions.md
@@ -1,0 +1,23 @@
+### `avoid-returning-useless-expressions`
+
+Removes any return arguments that are known to always evaluate to `undefined`. The list of methods that always return `undefined` is configurable using the `methodsReturningVoid` option.
+
+```sh
+jscodeshift -t shopify-codemods/transforms/avoid-returning-useless-expressions <file>
+```
+
+#### Example
+
+```js
+// using methodsThatIgnoreReturnValues: [{object: 'console', methods: ['log']}]
+function foo() {
+  return console.log('bar');
+}
+
+// BECOMES
+
+function foo() {
+  console.log('bar');
+  return;
+}
+```

--- a/packages/shopify-codemod/docs/remove-unused-expressions.md
+++ b/packages/shopify-codemod/docs/remove-unused-expressions.md
@@ -1,0 +1,28 @@
+### `remove-unused-expressions`
+
+Removes any expressions that don't have any possible side effects.
+
+```sh
+jscodeshift -t shopify-codemods/transforms/remove-unused-expressions <file>
+```
+
+#### Example
+
+```js
+foo;
+!foo;
+123;
+foo.bar;
+
+function foo() {};
+const foo = bar;
+foo.bar();
+delete foo.bar;
+
+// BECOMES:
+
+function foo() {};
+const foo = bar;
+foo.bar();
+delete foo.bar;
+```

--- a/packages/shopify-codemod/test/fixtures/avoid-returning-unsused-results/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/avoid-returning-unsused-results/basic.input.js
@@ -1,0 +1,19 @@
+_.each(foo, () => {
+  return foo.bar();
+});
+
+_.each(() => {
+  return foo.bar();
+}, someObj);
+
+_.each(() => {
+  function baz() {
+    return fuzz;
+  }
+
+  return foo.bar();
+});
+
+_._each(() => {
+  return foo.bar();
+});

--- a/packages/shopify-codemod/test/fixtures/avoid-returning-unsused-results/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/avoid-returning-unsused-results/basic.output.js
@@ -1,0 +1,23 @@
+_.each(foo, () => {
+  foo.bar();
+  return;
+});
+
+_.each(() => {
+  foo.bar();
+  return;
+}, someObj);
+
+_.each(() => {
+  function baz() {
+    return fuzz;
+  }
+
+  foo.bar();
+
+  return;
+});
+
+_._each(() => {
+  return foo.bar();
+});

--- a/packages/shopify-codemod/test/fixtures/avoid-returning-useless-expressions/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/avoid-returning-useless-expressions/basic.input.js
@@ -1,0 +1,24 @@
+function foo() {
+  return console.log();
+}
+
+function bar() {
+  return console.warn();
+}
+
+function baz() {
+  return somethingElse.log();
+}
+
+function qux() {
+  return console.somethingElse();
+}
+
+function fuzz(event) {
+  return event.preventDefault();
+}
+
+function buzz(evt) {
+  evt.preventDefault();
+  return evt.preventDefault();
+}

--- a/packages/shopify-codemod/test/fixtures/avoid-returning-useless-expressions/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/avoid-returning-useless-expressions/basic.output.js
@@ -1,0 +1,28 @@
+function foo() {
+  console.log();
+  return;
+}
+
+function bar() {
+  console.warn();
+  return;
+}
+
+function baz() {
+  return somethingElse.log();
+}
+
+function qux() {
+  return console.somethingElse();
+}
+
+function fuzz(event) {
+  event.preventDefault();
+  return;
+}
+
+function buzz(evt) {
+  evt.preventDefault();
+  evt.preventDefault();
+  return;
+}

--- a/packages/shopify-codemod/test/fixtures/remove-unused-expressions/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/remove-unused-expressions/basic.input.js
@@ -1,0 +1,26 @@
+'expose Foo.Bar';
+
+console.log('foo');
+foo.bar;
+'a string';
+123;
+foo;
+foo ? bar : baz;
+!foo.bar;
+
+export default foo;
+function foo() {}
+delete foo.bar;
+class Foo {}
+
+() => {
+  'expose Qux';
+  delete foo.bar;
+}
+
+const foo = () => {
+  'expose Qux';
+  foo.bar;
+  delete foo.bar;
+  return foo;
+}

--- a/packages/shopify-codemod/test/fixtures/remove-unused-expressions/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/remove-unused-expressions/basic.output.js
@@ -1,0 +1,14 @@
+'expose Foo.Bar';
+
+console.log('foo');
+
+export default foo;
+function foo() {}
+delete foo.bar;
+class Foo {}
+
+const foo = () => {
+  'expose Qux';
+  delete foo.bar;
+  return foo;
+}

--- a/packages/shopify-codemod/test/transforms/avoid-returning-unsused-results.test.js
+++ b/packages/shopify-codemod/test/transforms/avoid-returning-unsused-results.test.js
@@ -1,0 +1,15 @@
+import 'test-helper';
+import avoidReturningUnsusedResults from 'avoid-returning-unsused-results';
+
+describe('avoidReturningUnsusedResults', () => {
+  it('removes return arguments from specified callbacks', () => {
+    expect(avoidReturningUnsusedResults).to.transform('avoid-returning-unsused-results/basic', {
+      methodsThatIgnoreReturnValues: [
+        {
+          object: '_',
+          methods: ['each'],
+        },
+      ],
+    });
+  });
+});

--- a/packages/shopify-codemod/test/transforms/avoid-returning-useless-expressions.test.js
+++ b/packages/shopify-codemod/test/transforms/avoid-returning-useless-expressions.test.js
@@ -1,0 +1,19 @@
+import 'test-helper';
+import avoidReturningUselessExpressions from 'avoid-returning-useless-expressions';
+
+describe('avoidReturningUselessExpressions', () => {
+  it('transforms specified properties to never be returned', () => {
+    expect(avoidReturningUselessExpressions).to.transform('avoid-returning-useless-expressions/basic', {
+      methodsReturningVoid: [
+        {
+          object: 'console',
+          methods: ['log', 'warn'],
+        },
+        {
+          object: /ev(en)?t/,
+          methods: ['preventDefault'],
+        },
+      ],
+    });
+  });
+});

--- a/packages/shopify-codemod/test/transforms/remove-unused-expressions.test.js
+++ b/packages/shopify-codemod/test/transforms/remove-unused-expressions.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import removeUnusedExpressions from 'remove-unused-expressions';
+
+describe('removeUnusedExpressions', () => {
+  it('removes unused expressions', () => {
+    expect(removeUnusedExpressions).to.transform('remove-unused-expressions/basic');
+  });
+});

--- a/packages/shopify-codemod/transforms/avoid-returning-unsused-results.js
+++ b/packages/shopify-codemod/transforms/avoid-returning-unsused-results.js
@@ -1,0 +1,30 @@
+import {createMemberExpressionMatcher} from './utils';
+
+export default function avoidReturningUnsusedResults({source}, {jscodeshift: j}, {printOptions = {quote: 'single'}, methodsThatIgnoreReturnValues = []}) {
+
+  const isMatchingMemberExpression = createMemberExpressionMatcher(methodsThatIgnoreReturnValues);
+
+  return j(source)
+    .find(j.CallExpression, {
+      callee: isMatchingMemberExpression,
+      arguments: (args) => args.some(j.Function.check),
+    })
+    .forEach((path) => {
+      path
+        .get('arguments')
+        .filter(({node}) => j.Function.check(node))
+        .forEach((callbackPath) => {
+          const {node: scopeNode} = callbackPath;
+
+          j(path)
+            .find(j.ReturnStatement)
+            .filter((returnPath) => returnPath.scope.node === scopeNode)
+            .forEach((returnPath) => {
+              const argument = returnPath.get('argument');
+              returnPath.insertBefore(j.expressionStatement(argument.node));
+              argument.replace();
+            });
+        });
+    })
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/avoid-returning-useless-expressions.js
+++ b/packages/shopify-codemod/transforms/avoid-returning-useless-expressions.js
@@ -1,0 +1,20 @@
+import {createMemberExpressionMatcher} from './utils';
+
+export default function avoidReturningUselessExpressions({source}, {jscodeshift: j}, {printOptions = {quote: 'single'}, methodsReturningVoid = []}) {
+
+  const isMatchingMemberExpression = createMemberExpressionMatcher(methodsReturningVoid);
+
+  return j(source)
+    .find(j.ReturnStatement, {
+      argument: {
+        type: j.CallExpression.name,
+        callee: isMatchingMemberExpression,
+      },
+    })
+    .forEach((path) => {
+      const arg = path.get('argument');
+      path.insertBefore(j.expressionStatement(arg.node));
+      arg.replace();
+    })
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/remove-unused-expressions.js
+++ b/packages/shopify-codemod/transforms/remove-unused-expressions.js
@@ -1,0 +1,30 @@
+// This transform mostly mirrors the no-unused-expression ESLint rule:
+// https://github.com/eslint/eslint/blob/master/lib/rules/no-unused-expressions.js
+
+import {isDirective} from './utils';
+
+export default function removeUnusedExpressions({source}, {jscodeshift: j}, {printOptions = {quote: 'single'}}) {
+  const validUnaryOperators = new Set(['delete', 'void']);
+  function isValidUnaryExpression({node: {expression: {type, operator}}}) {
+    return type === 'UnaryExpression' && validUnaryOperators.has(operator);
+  }
+
+  function isValidExpression(expressionPath) {
+    const type = expressionPath.get('expression', 'type').value;
+    return (
+      /^(?:Assignment|Call|New|Update|Yield)Expression$/.test(type) ||
+      isValidUnaryExpression(expressionPath) ||
+      isDirective(expressionPath)
+    );
+  }
+
+  function isUnusedExpression(expressionPath) {
+    return !isValidExpression(expressionPath);
+  }
+
+  return j(source)
+    .find(j.ExpressionStatement)
+    .filter(isUnusedExpression)
+    .replaceWith()
+    .toSource(printOptions);
+}


### PR DESCRIPTION
Fixes https://github.com/Shopify/javascript/issues/115. Sorry for the big PR, I can break it up if people want.

This PR introduces three transforms: `avoid-returning-unused-results`, `avoid-returning-useless-expressions`, and `remove-unused-expressions`. These collectively solve two cases:

1. Returns in callbacks passed to methods that ignore return values.
2. Returns of method calls that always return `undefined`.

It will also help us get rid of unused expressions separate from the results of these transforms, which is really nice.

cc/ @GoodForOneFare @bouk @justinthec 