### PR TITLE
Add Docs Generation to Helper commands

### DIFF
--- a/packages/shopify-codemod/transform-cli/create-transform.js
+++ b/packages/shopify-codemod/transform-cli/create-transform.js
@@ -22,6 +22,11 @@ function generateTestSuiteJS({dasherizedName, camelizedName}) {
     .replace(/__CAMELIZED_NAME__/g, camelizedName);
 }
 
+function generateDocumentationMD({dasherizedName}) {
+  return readTemplateSync('documentation.md.template')
+    .replace(/__DASHERIZED_NAME__/g, dasherizedName);
+}
+
 module.exports = function createTransform(dasherizedName) {
   if (!dasherizedName) {
     throw new Error('Specify the transform\'s dasherized name as an argument.');
@@ -29,10 +34,16 @@ module.exports = function createTransform(dasherizedName) {
 
   utils.validateTransformName(dasherizedName);
   const transformInfo = utils.transformNameInfo(dasherizedName);
-  const {transformFilePath, testSuiteFilePath, fixtureDir} = transformInfo;
+  const {
+    transformFilePath,
+    testSuiteFilePath,
+    documentationFilePath,
+    fixtureDir
+  } = transformInfo;
 
   fs.writeFileSync(transformFilePath, generateTransformJS(transformInfo));
   fs.writeFileSync(testSuiteFilePath, generateTestSuiteJS(transformInfo));
+  fs.writeFileSync(documentationFilePath, generateDocumentationMD(transformInfo));
 
   fs.mkdirSync(fixtureDir);
 

--- a/packages/shopify-codemod/transform-cli/create-transform.js
+++ b/packages/shopify-codemod/transform-cli/create-transform.js
@@ -38,7 +38,7 @@ module.exports = function createTransform(dasherizedName) {
     transformFilePath,
     testSuiteFilePath,
     documentationFilePath,
-    fixtureDir
+    fixtureDir,
   } = transformInfo;
 
   fs.writeFileSync(transformFilePath, generateTransformJS(transformInfo));

--- a/packages/shopify-codemod/transform-cli/rename-transform.js
+++ b/packages/shopify-codemod/transform-cli/rename-transform.js
@@ -18,6 +18,7 @@ module.exports = function renameTransform(oldName, newName) {
 
   fs.renameSync(oldInfo.transformFilePath, newInfo.transformFilePath);
   fs.renameSync(oldInfo.testSuiteFilePath, newInfo.testSuiteFilePath);
+  fs.renameSync(oldInfo.documentationFilePath, newInfo.documentationFilePath);
   fs.renameSync(oldInfo.fixtureDir, newInfo.fixtureDir);
 
   const transformJS = fs
@@ -30,4 +31,9 @@ module.exports = function renameTransform(oldName, newName) {
     .replace(new RegExp(oldInfo.dasherizedName, 'g'), newInfo.dasherizedName)
     .replace(new RegExp(oldInfo.camelizedName, 'g'), newInfo.camelizedName);
   fs.writeFileSync(newInfo.testSuiteFilePath, testSuiteJS);
+
+  const documentationMD = fs
+    .readFileSync(newInfo.documentationFilePath, 'utf8')
+    .replace(new RegExp(oldInfo.dasherizedName, 'g'), newInfo.dasherizedName);
+  fs.writeFileSync(newInfo.documentationFilePath, documentationMD);
 };

--- a/packages/shopify-codemod/transform-cli/templates/documentation.md.template
+++ b/packages/shopify-codemod/transform-cli/templates/documentation.md.template
@@ -1,0 +1,17 @@
+### `__DASHERIZED_NAME__`
+
+Description of transform. CHANGE THIS
+
+```sh
+jscodeshift -t shopify-codemod/transforms/__DASHERIZED_NAME__ <file>
+```
+
+#### Example
+
+```js
+EXAMPLE INPUT CHANGE THIS
+
+// BECOMES:
+
+EXAMPLE OUTPUT CHANGE THIS
+```

--- a/packages/shopify-codemod/transform-cli/transform-management-utils.js
+++ b/packages/shopify-codemod/transform-cli/transform-management-utils.js
@@ -14,6 +14,7 @@ module.exports.validateTransformName = function(dasherizedName) {
 module.exports.transformNameInfo = function(dasherizedName) {
   const transformFilePath = path.join('transforms', `${dasherizedName}.js`);
   const testSuiteFilePath = path.join('test', 'transforms', `${dasherizedName}.test.js`);
+  const documentationFilePath = path.join('docs', `${dasherizedName}.md`);
   const fixtureDir = path.join('test', 'fixtures', dasherizedName);
 
   return {
@@ -21,6 +22,7 @@ module.exports.transformNameInfo = function(dasherizedName) {
     camelizedName: camelize(dasherizedName),
     transformFilePath,
     testSuiteFilePath,
+    documentationFilePath,
     fixtureDir,
   };
 };


### PR DESCRIPTION
Addresses: https://github.com/Shopify/javascript/issues/176

When running `bin/create-transform transform-name`:
* `docs/transform-name.md` is created using the template `transform-cli/templates/documentation.md.template`

When running `bin/rename-transform transform-name other-transform-name`:
* `docs/transform-name.md` is renamed to `docs/other-transform-name.md` and has all dash-cased instances of `tranform-name` replaced with `other-transform-name` in its contents.

@GoodForOneFare @lemonmade 