### PR TITLE
Add arrow-body-style guidance for a singular multiline return.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1353,6 +1353,13 @@ npm run lint
     })
     .filter((x) => {
       return x < 6;
+    })
+    .filter((a) => {
+      return (
+        a &&
+        really &&
+        (long || expression)
+      );
     });
 
   // doesn't return an object with `foo` key, actually returns nothing!
@@ -1361,7 +1368,12 @@ npm run lint
   // good
   [1, 2, 3]
     .map((x) => (x * x) + 1)
-    .filter((x) => x < 6);
+    .filter((x) => x < 6)
+    .filter((a) => (
+      a &&
+      really &&
+      (long || expression)
+    ));
 
   runCallback((foo) => {
     return {foo};


### PR DESCRIPTION
Currently our [`arrow-body-style:as-needed`](http://eslint.org/docs/rules/arrow-body-style#as-needed) rule only allow arrow functions to use block statements when they contain multiple lines.

However when working with an arrow function with a single very long expression, one may be tempted to break it up onto multiple lines using a block statement like so:

```js
body: (body) => {
  return (
    body.length === 1 &&
    (j.Identifier.check(body[0].expression) || j.MemberExpression.check(body[0].expression))
  );
},
```

This however will violate the `arrow-body-style:as-needed` rule.

This added guide to the readme provides the correct alternative to not break the rule while still breaking up the long expression onto multiple lines.

@lemonmade 