### PR TITLE
Fix invalid finder criteria in split-return-assignments

### DIFF
--- a/packages/shopify-codemod/test/fixtures/split-return-assignments/sanity.input.js
+++ b/packages/shopify-codemod/test/fixtures/split-return-assignments/sanity.input.js
@@ -1,0 +1,7 @@
+function foo() {
+  bar();
+};
+
+function foo() {
+  return "bar";
+};

--- a/packages/shopify-codemod/test/fixtures/split-return-assignments/sanity.output.js
+++ b/packages/shopify-codemod/test/fixtures/split-return-assignments/sanity.output.js
@@ -1,0 +1,7 @@
+function foo() {
+  bar();
+};
+
+function foo() {
+  return "bar";
+};

--- a/packages/shopify-codemod/test/transforms/split-return-assignments.test.js
+++ b/packages/shopify-codemod/test/transforms/split-return-assignments.test.js
@@ -25,4 +25,8 @@ describe('splitReturnAssignments', () => {
   it('splits up non "=" operators', () => {
     expect(splitReturnAssignments).to.transform('split-return-assignments/operators');
   });
+
+  it('ignores returns without assignments', () => {
+    expect(splitReturnAssignments).to.transform('split-return-assignments/sanity');
+  });
 });

--- a/packages/shopify-codemod/transforms/split-return-assignments.js
+++ b/packages/shopify-codemod/transforms/split-return-assignments.js
@@ -5,9 +5,11 @@ export default function splitReturnAssignments({source}, {jscodeshift: j}, {prin
   sourceAST
     .find(j.Function, {
       body: {
-        body: matchLast(j.ReturnStatement, {
-          type: 'ReturnStatement',
-          argument: j.AssignmentExpression,
+        body: matchLast({
+          type: j.ReturnStatement.name,
+          argument: {
+            type: j.AssignmentExpression.name,
+          },
         }),
       },
     })


### PR DESCRIPTION
/cc @lemonmade, @justinthec.

Fixed #166.