### PR TITLE
Modify transform to use namespaced import when finding named exports

### DIFF
--- a/packages/shopify-codemod/test/fixtures/global-reference-to-import/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/global-reference-to-import/basic.input.js
@@ -2,3 +2,4 @@ console.log(App.Components.UIList, App.Components.UIList.WHATEVER);
 console.log(App.Components.Widget);
 console.log(App.Components.Element);
 console.log(App.Components.NonExistant);
+console.log(App.Components.NamedExports, App.Components.NamedExports.namedMember());

--- a/packages/shopify-codemod/test/fixtures/global-reference-to-import/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/global-reference-to-import/basic.output.js
@@ -1,3 +1,4 @@
+import * as NamedExports from 'app/components/named_exports';
 import Element from 'app/components/element';
 import Widget from 'app/components/widget';
 import UIList from 'app/components/ui_list';
@@ -5,3 +6,4 @@ console.log(UIList, UIList.WHATEVER);
 console.log(Widget);
 console.log(Element);
 console.log(App.Components.NonExistant);
+console.log(NamedExports, NamedExports.namedMember());

--- a/packages/shopify-codemod/test/fixtures/javascripts/app/components/named_exports.js
+++ b/packages/shopify-codemod/test/fixtures/javascripts/app/components/named_exports.js
@@ -1,0 +1,2 @@
+'expose App.Components.NamedExports'
+export function namedMember() {}

--- a/packages/shopify-codemod/transforms/global-reference-to-import.js
+++ b/packages/shopify-codemod/transforms/global-reference-to-import.js
@@ -73,6 +73,7 @@ export default function globalReferenceToImport(
     if (extname(filename) === '.coffee') {
       return [];
     }
+    // eslint-disable-next-line no-sync
     const namedExports = j(fs.readFileSync(filename).toString())
       .find(j.ExportNamedDeclaration);
     return namedExports.paths();
@@ -110,7 +111,7 @@ export default function globalReferenceToImport(
           const file = getDeclaringFile(member);
           if (file === null) { return null; }
           const name = findLastMember(node).name;
-          const hasNamedExports = findNamedExports(file).length > 0;
+          const hasNamedExports = (findNamedExports(file).length > 0);
 
           imports.set(member, {file, name, hasNamedExports});
           return name;
@@ -163,7 +164,7 @@ export default function globalReferenceToImport(
         insertAfterDirectives(
           body,
           j.importDeclaration([
-            hasNamedExports ? j.importNamespaceSpecifier(identifier) : j.importDefaultSpecifier(identifier)
+            hasNamedExports ? j.importNamespaceSpecifier(identifier) : j.importDefaultSpecifier(identifier),
           ], j.literal(relativePath(file)))
         );
       }


### PR DESCRIPTION
Fixes: https://github.com/Shopify/javascript/issues/184

Given a named export:
```js
'expose Foo.Bar'
export function baz() {}
```
Those referencing it will now go from:
```js
Foo.Bar.baz();
```
to using namespace imports:
```js
import * as Bar from 'path/to/bar';
Bar.baz();
```

**Note:** The runtime of the test is marked as red by `npm test` at 106 ms.
![image](https://cloud.githubusercontent.com/assets/2578036/16213703/7508df8c-371f-11e6-8247-110108868ed6.png)
This is almost certainly due to my use of `fs.fileReadSync`. Any alternative suggestions welcome 🙏 

@lemonmade @GoodForOneFare 