### PR TITLE
Splits up assignments in if statement parameters

### DIFF
--- a/packages/esify/lib/codemod.js
+++ b/packages/esify/lib/codemod.js
@@ -3,6 +3,7 @@ var jscodeshift = require('jscodeshift');
 require('babel-register')({ignore: false});
 
 var TRANSFORMS = [
+  {path: 'shopify-codemod/transforms/split-if-assignments'},
   {path: 'shopify-codemod/transforms/coffeescript-soak-to-condition'},
   {path: 'shopify-codemod/transforms/ternary-statement-to-if-statement'},
   {path: 'shopify-codemod/transforms/remove-useless-return-from-test', test: true},
@@ -52,6 +53,7 @@ var TRANSFORMS = [
   {path: 'shopify-codemod/transforms/computed-literal-keys-to-dot-notation'},
   {path: 'shopify-codemod/transforms/rename-identifier'},
   {path: 'shopify-codemod/transforms/rename-property'},
+  {path: 'shopify-codemod/transforms/split-return-assignments'},
   // constant-function-expression-to-statement and global-reference-to-import need
   // `const` references, so they must happen after `no-vars`
   {path: 'js-codemod/transforms/no-vars'},

--- a/packages/shopify-codemod/docs/split-if-assignments.md
+++ b/packages/shopify-codemod/docs/split-if-assignments.md
@@ -1,0 +1,33 @@
+### `split-if-assignments`
+
+Moves assignments within an `if`'s condition to before the `if`.
+
+See eslint's [`no-cond-assign`](http://eslint.org/docs/rules/no-cond-assign) rule for more details.
+
+```sh
+jscodeshift -t shopify-codemod/transforms/split-if-assignments <file>
+```
+
+#### Example
+
+```js
+if (foo = 'bar') {
+  qux();
+}
+
+if (foo = bar()) {
+  qux();
+}
+
+// BECOMES:
+
+foo = 'bar';
+if (foo) {
+  qux();
+}
+
+foo = bar();
+if (foo) {
+  qux();
+}
+```

--- a/packages/shopify-codemod/test/fixtures/split-if-assignments/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/split-if-assignments/basic.input.js
@@ -1,0 +1,19 @@
+if (foo = bar) {
+
+}
+
+if (foo = bar[0]) {
+  foo();
+}
+
+if (foo = false) {
+  foo();
+}
+
+if (foo = bar = baz) {
+
+}
+
+if (baz = qux()) {
+  foobar = foo;
+}

--- a/packages/shopify-codemod/test/fixtures/split-if-assignments/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/split-if-assignments/basic.output.js
@@ -1,0 +1,28 @@
+foo = bar;
+if (foo) {
+
+}
+
+foo = bar[0];
+
+if (foo) {
+  foo();
+}
+
+foo = false;
+
+if (foo) {
+  foo();
+}
+
+foo = bar = baz;
+
+if (foo) {
+
+}
+
+baz = qux();
+
+if (baz) {
+  foobar = foo;
+}

--- a/packages/shopify-codemod/test/transforms/split-if-assignments.test.js
+++ b/packages/shopify-codemod/test/transforms/split-if-assignments.test.js
@@ -1,0 +1,8 @@
+import 'test-helper';
+import transform from 'split-if-assignments';
+
+describe('splitIfAssignments', () => {
+  it('splits if-assigments into assignments and ifs', () => {
+    expect(transform).to.transform('split-if-assignments/basic');
+  });
+});

--- a/packages/shopify-codemod/transforms/split-if-assignments.js
+++ b/packages/shopify-codemod/transforms/split-if-assignments.js
@@ -1,0 +1,13 @@
+export default function splitIfAssignments({source}, {jscodeshift: j}, {printOptions = {}}) {
+  return j(source)
+    .find(j.IfStatement, {
+      test: {
+        type: j.AssignmentExpression.name,
+      },
+    }).forEach((path) => {
+      const assignment = path.get('test');
+      path.insertBefore(j.expressionStatement(assignment.node));
+      assignment.replace(assignment.node.left);
+    })
+    .toSource(printOptions);
+}


### PR DESCRIPTION
Fixes #103.  Simplified version of Andy's PR: https://github.com/Shopify/javascript/pull/154.

Rebased, cleaned up, and added docs.  Also removed support for `SequenceExpression`s because I don't see those anywhere in the core codebase.

/cc @lemonmade, @justinthec