### PR TITLE
Use a looser peerDependencies for eslint-plugin-shopify

### DIFF
--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "peerDependencies": {
-    "eslint": "~2.10.0"
+    "eslint": "2.x"
   },
   "dependencies": {
     "babel-eslint": "~6.0.0",


### PR DESCRIPTION
@lemonmade we don't want to have to release a new version for every minor eslint upgrade, so let's only pin the major version