### PR TITLE
Minor linting updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- Removed the requirement to omit braces for arrow functions whose body is a single return statement. The styleguide now recommends omitting for simple, single-line return statements, and braces are permitted where they improve legibility.
+- Removed lint checks for sorting of properties in React components (the guidance on ordering remains, but the linting rule was too coarse to be useful in all situations).
+- Turned off the lint rule requiring a default export in modules exporting only a single binding to allow for modules that make sense as utilities but export only a single named binding.
+
+### Fixed
+- `shopify/require-flow` linting rule now understands flow directives in line comments (in addition to block comments).
 
 ## [12.3.4]
 ### Added

--- a/README.md
+++ b/README.md
@@ -1345,7 +1345,7 @@ npm run lint
 
   ```js
   // bad
-  [1, 2, 3]
+  const result = [1, 2, 3]
     .map((x) => {
       return (x * x) + 1;
     })
@@ -1357,7 +1357,9 @@ npm run lint
   runCallback((foo) => {foo});
 
   // good
-  [1, 2, 3].map((x) => (x * x) + 1).filter((x) => x < 6);
+  const result = [1, 2, 3]
+    .map((x) => (x * x) + 1)
+    .filter((x) => x < 6);
 
   runCallback((foo) => {
     return {foo};

--- a/README.md
+++ b/README.md
@@ -1339,9 +1339,7 @@ npm run lint
   (good) => 'fabulous'
   ```
 
-- [10.1](#10.1) <a name="10.1"></a> If the body of your arrow function takes only a single expression, omit the braces and make use of the implicit `return`. If you are returning an object, however, you must use braces and an explicit `return`.
-
-  > Why? It reads better when multiple such functions are chained together.
+- [10.1](#10.1) <a name="10.1"></a> If the body of your arrow function takes only a single expression, you can omit the braces and make use of the implicit `return`. If your function’s body has more than one expression, it returns an object, or it returns something that spans multiple lines, you can use braces and an explicit `return`.
 
   ESLint rule: [`arrow-body-style`](http://eslint.org/docs/rules/arrow-body-style.html)
 
@@ -1353,27 +1351,13 @@ npm run lint
     })
     .filter((x) => {
       return x < 6;
-    })
-    .filter((a) => {
-      return (
-        a &&
-        really &&
-        (long || expression)
-      );
     });
 
   // doesn't return an object with `foo` key, actually returns nothing!
   runCallback((foo) => {foo});
 
   // good
-  [1, 2, 3]
-    .map((x) => (x * x) + 1)
-    .filter((x) => x < 6)
-    .filter((a) => (
-      a &&
-      really &&
-      (long || expression)
-    ));
+  [1, 2, 3].map((x) => (x * x) + 1).filter((x) => x < 6);
 
   runCallback((foo) => {
     return {foo};

--- a/packages/eslint-plugin-shopify/lib/config/esnext.js
+++ b/packages/eslint-plugin-shopify/lib/config/esnext.js
@@ -34,7 +34,15 @@ module.exports = {
     require('./rules/sort-class-members'),
     require('./rules/import'),
     {
-      'no-param-reassign': 'warn', // because of default params
+      // default params
+      'no-param-reassign': 'warn',
+      // Rules override by the Babel plugin
+      'array-bracket-spacing': 'off',
+      'arrow-parens': 'off',
+      'generator-star-spacing': 'off',
+      'new-cap': 'off',
+      'object-curly-spacing': 'off',
+      'object-shorthand': 'off',
     }
   ),
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/babel.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/babel.js
@@ -1,3 +1,6 @@
+// Make sure that any rules here that override default ESLint rules are
+// also turned off in configs that include these rules.
+
 module.exports = {
   // Handles destructuring arrays with flow type in function parameters
   'babel/array-bracket-spacing': ['warn', 'never'],

--- a/packages/eslint-plugin-shopify/lib/config/rules/ecmascript-6.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/ecmascript-6.js
@@ -2,19 +2,19 @@
 
 module.exports = {
   // Require braces in arrow function body
-  'arrow-body-style': ['error', 'as-needed'],
+  'arrow-body-style': 'off',
   // Require parens in arrow function arguments
-  'arrow-parens': 'off',
+  'arrow-parens': ['warn', 'always'],
   // Require space before/after arrow function's arrow
   'arrow-spacing': ['warn', {before: true, after: true}],
   // Verify super() callings in constructors
   'constructor-super': 'error',
   // Enforce the spacing around the * in generator functions
-  'generator-star-spacing': 'off',
+  'generator-star-spacing': ['warn', 'after'],
   // Disallow modifying variables of class declarations
   'no-class-assign': 'warn',
   // Disallow arrow functions where they could be confused with comparisons
-  'no-confusing-arrow': ['error', {allowParens: false}],
+  'no-confusing-arrow': ['error', {allowParens: true}],
   // Disallow modifying variables that are declared using const
   'no-const-assign': 'error',
   // Disallow duplicate name in class members

--- a/packages/eslint-plugin-shopify/lib/config/rules/import.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/import.js
@@ -56,5 +56,5 @@ module.exports = {
   // Enforce a newline after import statements
   'import/newline-after-import': 'warn',
   // Prefer a default export if module exports a single name
-  'import/prefer-default-export': 'warn',
+  'import/prefer-default-export': 'off',
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/react.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/react.js
@@ -76,19 +76,7 @@ module.exports = {
   // Prevent extra closing tags for components without children
   'react/self-closing-comp': 'warn',
   // Enforce component methods order
-  'react/sort-comp': [
-    'warn',
-    {
-      order: [
-        'static-methods',
-        'statics',
-        'constructor',
-        'lifecycle',
-        'everything-else',
-        'render',
-      ],
-    },
-  ],
+  'react/sort-comp': 'off',
   // Prevent missing parentheses around multilines JSX
   'react/wrap-multilines': 'warn',
   'react/prefer-es6-class': 'error',

--- a/packages/eslint-plugin-shopify/lib/config/rules/stylistic-issues.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/stylistic-issues.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   // Enforce spacing inside array brackets
-  'array-bracket-spacing': 'off',
+  'array-bracket-spacing': ['warn', 'never'],
   // Disallow or enforce spaces inside of single line blocks
   'block-spacing': ['warn', 'always'],
   // Enforce one true brace style
@@ -50,7 +50,7 @@ module.exports = {
   // Specify the maximum number of statements allowed per line
   'max-statements-per-line': ['warn', {max: 2}],
   // Require a capital letter for constructors
-  'new-cap': 'off',
+  'new-cap': ['error', {newIsCap: true, capIsNew: false}],
   // Disallow the omission of parentheses when invoking a constructor with no arguments
   'new-parens': 'warn',
   // Allow/disallow an empty newline after var statement

--- a/packages/eslint-plugin-shopify/lib/rules/require-flow.js
+++ b/packages/eslint-plugin-shopify/lib/rules/require-flow.js
@@ -5,7 +5,7 @@ var FLOW_REGEX = /@flow/;
 var EXPLICIT_FLOW_REGEX = /@(no)?flow/;
 
 function commentIsFlowDirective(comment, regex) {
-  return Boolean(comment) && comment.type === 'Block' && comment.start === 0 && regex.test(comment.value);
+  return Boolean(comment) && comment.start === 0 && regex.test(comment.value);
 }
 
 module.exports = function(context) {

--- a/packages/eslint-plugin-shopify/tests/lib/rules/require-flow.js
+++ b/packages/eslint-plugin-shopify/tests/lib/rules/require-flow.js
@@ -18,9 +18,12 @@ const confusingFlow = `var foo = 'bar'
 ruleTester.run('require-flow', rule, {
   valid: [
     {code: withFlow, parser: 'babel-eslint'},
+    {code: `// @flow\n${withFlow.split('\n')[1]}`, parser: 'babel-eslint'},
     {code: noFlow, options: ['never']},
     {code: withFlow, options: ['always'], parser: 'babel-eslint'},
     {code: confusingFlow, options: ['never']},
+    {code: explicitNoFlow, options: ['explicit'], parser: 'babel-eslint'},
+    {code: `// @noflow\n${explicitNoFlow.split('\n')[1]}`, options: ['explicit'], parser: 'babel-eslint'},
   ],
   invalid: [
     {
@@ -29,12 +32,6 @@ ruleTester.run('require-flow', rule, {
         message: 'You must include a @flow declaration at the top of your file.',
         type: 'Program',
       }],
-    },
-    {
-      code: explicitNoFlow,
-      parser: 'babel-eslint',
-      options: ['explicit'],
-      errors: [],
     },
     {
       code: noFlow,
@@ -51,6 +48,15 @@ ruleTester.run('require-flow', rule, {
       options: ['never'],
       errors: [{
         message: 'You must not include a @flow declaration in your file.',
+        type: 'Program',
+      }],
+    },
+    {
+      code: explicitNoFlow,
+      parser: 'babel-eslint',
+      options: ['always'],
+      errors: [{
+        message: 'You must include a @flow declaration at the top of your file.',
         type: 'Program',
       }],
     },

--- a/react/README.md
+++ b/react/README.md
@@ -382,7 +382,7 @@ This guide provides a few guidelines on writing sensible React. Many of these ru
   }
   ```
 
-- [4.8](#4.8) <a name="4.8"></a> Maintain a sensible ordering of methods in your component. At a high level, order the component as follows: statics, constructor, lifecycle methods, other methods (like handlers and helpers), and, finally, render (and any methods you have broken render up into).
+- [4.8](#4.8) <a name="4.8"></a> Maintain a sensible ordering of methods in your component. At a high level, order the component as follows: statics and instance class properties, constructor, lifecycle methods, other methods (like handlers and helpers), and, finally, render (and any methods you have broken render up into).
 
   > Why? A consistent ordering between components helps other developers find what they are looking for more quickly.
 


### PR DESCRIPTION
This PR makes a few small JavaScript linting/ styleguide updates:

- Made it so that `require-flow` allows `@flow` to appear in a line comment (which is apparently allowed now).
- Removed the requirement to omit the braces for arrow functions that have only a return statement and updated the guidance for them to suggest (but not require) omitting the braces for simple return-only arrow functions.
- Turned off linting rules that enforced sorting of properties in React components. This was annoying in my experience and doesn't have the granularity to make it work well with class properties.
- Turned off a rule that required you to use a default export when your module exports only one identifier. IMO some modules make more sense as groups of named exports (usually utility-like things), even if you currently only have one export from that group.

Thoughts? @GoodForOneFare @bouk @tessalt @Shopify/fed 