### PR TITLE
Turn off `no-duplicate-imports` rule

### DIFF
--- a/packages/eslint-plugin-shopify/lib/config/rules/ecmascript-6.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/ecmascript-6.js
@@ -19,8 +19,8 @@ module.exports = {
   'no-const-assign': 'error',
   // Disallow duplicate name in class members
   'no-dupe-class-members': 'error',
-  // Disallow duplicate module imports
-  'no-duplicate-imports': 'error',
+  // Disallow duplicate module imports (disabled, as import/no-duplicates does the same job but better)
+  'no-duplicate-imports': 'off',
   // Disallow use of the new operator with the Symbol object
   'no-new-symbol': 'error',
   // Disallow to use this/super before super() calling in constructors.


### PR DESCRIPTION
`import/no-duplicates` is better, as it handles Flow and different paths pointing to the same file.

@lemonmade

[More info about import/no-duplicates](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md)