### PR TITLE
Update all dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,12 @@ npm run lint
   function fine() { return 'but don’t push it!'; }
   ```
 
+- [4.11](#4.11) <a name="4.11"></a> Line comments should appear above the line they are commenting, rather than at the end of the line or below it.
+
+  > Why? End-of-line comments can be harder to read since they lead to longer lines. Comments above the line you are documenting provides a more natural experience when reading the code, as it follows how we typically read other forms of text.
+
+  ESLint rule: [`line-comment-position`](http://eslint.org/docs/rules/line-comment-position.html)
+
 [↑ scrollTo('#table-of-contents')](#table-of-contents)
 
 
@@ -1593,9 +1599,35 @@ npm run lint
 
 - [12.2](#12.2) <a name="12.2"></a> Limit use of generators and proxies, as these don’t transpile well (or at all) to ES5.
 
+- [12.3](#12.3) <a name="12.3"></a> Prefer binary, octal, and hexadecimal literals over using `parseInt`.
+
+  ESLint rule: [`prefer-numeric-literals`](http://eslint.org/docs/rules/prefer-numeric-literals.html)
+
+  ```js
+  // bad
+  const twoSixtyFiveInHex = parseInt('1F7', 16);
+
+  // good
+  const twoSixtyFiveInHex = 0x1F7;
+  ```
+
+- [12.4](#12.4) <a name="12.4"></a> Always provide a description when creating a `Symbol`.
+
+  > Why? You will get a more descriptive representation of that symbol in most developer tools.
+
+  ESLint rule: [`symbol-description`](http://eslint.org/docs/rules/symbol-description.html)
+
+  ```js
+  // bad
+  const badSymbol = Symbol();
+
+  // good
+  const goodSymbol = Symbol('Good!');
+  ```
+
 ### Destructuring
 
-- [12.3](#12.3) <a name="12.3"></a> Use object destructuring to retrieve multiple properties from an object.
+- [12.5](#12.5) <a name="12.5"></a> Use object destructuring to retrieve multiple properties from an object.
 
   > Why? Destructuring removes a lot of boilerplate and encourages you to refer to properties by the same name everywhere they are referenced.
 
@@ -1620,7 +1652,7 @@ npm run lint
   }
   ```
 
-- [12.4](#12.4) <a name="12.4"></a> Use array destructuring rather than manually accessing items by their index. If your array has more than a few entries, and you are selecting only a small number of them, continue to use index notation.
+- [12.6](#12.6) <a name="12.6"></a> Use array destructuring rather than manually accessing items by their index. If your array has more than a few entries, and you are selecting only a small number of them, continue to use index notation.
 
   ```js
   const array = [1, 2];
@@ -1639,7 +1671,7 @@ npm run lint
   const fifthLong = longArray[4];
   ```
 
-- [12.5](#12.5) <a name="12.5"></a> If you need to return multiple values from a function, return them using an object rather than an array.
+- [12.7](#12.7) <a name="12.7"></a> If you need to return multiple values from a function, return them using an object rather than an array.
 
   > Why? Call sites that use destructuring to access your return values need to care about the ordering when returning an array, making them fragile to change.
 
@@ -1661,7 +1693,7 @@ npm run lint
   const {left, top} = positionForNode(node);
   ```
 
-- [12.6](#12.6) <a name="12.6"></a> You can create highly readable functions by using one positional argument, followed by a destructured object. You can even provide different local names for the destructured arguments to have both an expressive external API and concise internal references.
+- [12.8](#12.8) <a name="12.8"></a> You can create highly readable functions by using one positional argument, followed by a destructured object. You can even provide different local names for the destructured arguments to have both an expressive external API and concise internal references.
 
   ```js
   // fine, but too many positional arguments, so it's hard for call sites to know what to do
@@ -1688,7 +1720,7 @@ npm run lint
 
 ### Classes
 
-- [12.7](#12.7) <a name="12.7"></a> Use classes with care: they do not behave in exactly the way you would expect in other languages, and JavaScript provides many mechanisms (closures, simple objects, etc) that solve problems for which you might use a class in another language. The rule of thumb is: use the right tool for the job!
+- [12.9](#12.9) <a name="12.9"></a> Use classes with care: they do not behave in exactly the way you would expect in other languages, and JavaScript provides many mechanisms (closures, simple objects, etc) that solve problems for which you might use a class in another language. The rule of thumb is: use the right tool for the job!
 
   ```js
   // bad
@@ -1731,7 +1763,7 @@ npm run lint
   const result = takeAction({first: 'foo', second: 'bar'});
   ```
 
-- [12.8](#12.8) <a name="12.8"></a> If you want to use constructor functions, use `class` syntax. Avoid creating them by manually updating the prototype.
+- [12.10](#12.10) <a name="12.10"></a> If you want to use constructor functions, use `class` syntax. Avoid creating them by manually updating the prototype.
 
   > Why? `class` syntax is more concise and will be more familiar for developers trained in other languages.
 
@@ -1755,7 +1787,7 @@ npm run lint
   }
   ```
 
-- [12.9](#12.9) <a name="12.9"></a> If you are subclassing, your subclass’s constructor should always call `super` before referencing `this`.
+- [12.11](#12.11) <a name="12.11"></a> If you are subclassing, your subclass’s constructor should always call `super` before referencing `this`.
 
   > Why? If your forget to call `super` in your subclass constructor, your object will be uninitialized and calling `this` will result in an exception.
 
@@ -1781,7 +1813,7 @@ npm run lint
   }
   ```
 
-- [12.10](#12.10) <a name="12.10"></a> When declaring static members or properties, prefer the `static` keyword to direct assignment to the class object. Put `static` members at the top of your class definition.
+- [12.12](#12.12) <a name="12.12"></a> When declaring static members or properties, prefer the `static` keyword to direct assignment to the class object. Put `static` members at the top of your class definition.
 
   > Why? Using the `static` keyword is more expressive and keeps the entire class definition in one place.
 
@@ -1805,9 +1837,39 @@ npm run lint
   }
   ```
 
+- [12.13](#12.13) <a name="12.13"></a> Instance methods that don’t refer to `this` don’t need to be instance methods. If they relate to the class, make them static methods; otherwise, make them functions in scope.
+
+  > Why? This pattern is generally a sign that you are providing a bad public API for the class, and should either hide this method (if it’s an implementation detail) or expose it as a utility method.
+
+  ESLint rule: [`class-methods-use-this`](http://eslint.org/docs/rules/class-methods-use-this.html)
+
+  ```js
+  // bad
+  class BadClass {
+    badMethod(string) {
+      console.log(string.toUpperCase());
+    }
+
+    anotherMethod() {
+      return this.badMethod('oops!');
+    }
+  }
+
+  // good
+  function goodFunction(string) {
+    console.log(string.toUpperCase());
+  }
+
+  class GoodClass {
+    anotherMethod() {
+      return goodFunction('oops!');
+    }
+  }
+  ```
+
 ### Modules
 
-- [12.11](#12.11) <a name="12.11"></a> Always use modules (`import`/ `export`) over a non-standard module system (CommonJS being the most popular of these).
+- [12.14](#12.14) <a name="12.14"></a> Always use modules (`import`/ `export`) over a non-standard module system (CommonJS being the most popular of these).
 
   > Why? Modules are the future, so let’s get a head start. You can always transpile to a preferred module system.
 
@@ -1821,7 +1883,7 @@ npm run lint
   export default feelGoodAboutIt();
   ```
 
-- [12.12](#12.12) <a name="12.12"></a> Avoid complex relative import paths. It is usually fairly easy and much clearer to add the root of your project to the load path.
+- [12.15](#12.15) <a name="12.15"></a> Avoid complex relative import paths. It is usually fairly easy and much clearer to add the root of your project to the load path.
 
   > Why? Relative paths are fragile and hard to parse for humans.
 

--- a/README.md
+++ b/README.md
@@ -1839,7 +1839,7 @@ npm run lint
 
 - [12.13](#12.13) <a name="12.13"></a> Instance methods that don’t refer to `this` don’t need to be instance methods. If they relate to the class, make them static methods; otherwise, make them functions in scope.
 
-  > Why? This pattern is generally a sign that you are providing a bad public API for the class, and should either hide this method (if it’s an implementation detail) or expose it as a utility method.
+  > Why? This pattern is generally a sign that you are providing a bad public API for the class, and should either hide this method (if it’s an implementation detail) or export it as a utility method.
 
   ESLint rule: [`class-methods-use-this`](http://eslint.org/docs/rules/class-methods-use-this.html)
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-preset-shopify": "file:./packages/babel-preset-shopify",
     "chai": "3.x",
     "coveralls": "2.x",
-    "eslint": "3.3.x",
+    "eslint": "3.5.x",
     "eslint-plugin-shopify": "file:./packages/eslint-plugin-shopify",
     "isparta": "4.x",
     "istanbul": "0.x",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-preset-shopify": "file:./packages/babel-preset-shopify",
     "chai": "3.x",
     "coveralls": "2.x",
-    "eslint": "3.5.x",
+    "eslint": "3.7.x",
     "eslint-plugin-shopify": "file:./packages/eslint-plugin-shopify",
     "isparta": "4.x",
     "istanbul": "0.x",

--- a/packages/babel-preset-shopify/package.json
+++ b/packages/babel-preset-shopify/package.json
@@ -17,21 +17,21 @@
     ]
   },
   "dependencies": {
-    "babel-plugin-transform-es2015-destructuring": "^6.9.0",
+    "babel-plugin-transform-es2015-destructuring": "^6.16.0",
     "babel-plugin-transform-es2015-function-name": "^6.9.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.14.0",
-    "babel-plugin-transform-es2015-parameters": "^6.11.4",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.16.0",
+    "babel-plugin-transform-es2015-parameters": "^6.17.0",
     "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
     "babel-plugin-transform-es2015-spread": "^6.8.0",
     "babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
     "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
     "babel-plugin-transform-export-extensions": "^6.5.0",
     "babel-plugin-transform-inline-environment-variables": "^6.5.0",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-es2016": "^6.11.3",
-    "babel-preset-es2017": "^6.14.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-2": "^6.5.0",
+    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-es2016": "^6.16.0",
+    "babel-preset-es2017": "^6.16.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-2": "^6.17.0",
     "semver": "^5.3.0"
   }
 }

--- a/packages/chai-jscodeshift/test/test-helper.js
+++ b/packages/chai-jscodeshift/test/test-helper.js
@@ -8,6 +8,7 @@ global.expect = expect;
 global.assert = assert;
 global.sinon = sinon.sandbox.create();
 
+// eslint-ignore-next-line mocha/no-top-level-hooks
 afterEach(() => {
   sinon.restore();
 });

--- a/packages/chai-jscodeshift/test/test-helper.js
+++ b/packages/chai-jscodeshift/test/test-helper.js
@@ -8,7 +8,7 @@ global.expect = expect;
 global.assert = assert;
 global.sinon = sinon.sandbox.create();
 
-// eslint-ignore-next-line mocha/no-top-level-hooks
+// eslint-disable-next-line mocha/no-top-level-hooks
 afterEach(() => {
   sinon.restore();
 });

--- a/packages/esify/package.json
+++ b/packages/esify/package.json
@@ -20,11 +20,11 @@
   },
   "bin": "./bin/esify",
   "dependencies": {
-    "babel-register": "^6.9.0",
+    "babel-register": "^6.16.3",
     "chalk": "^1.1.3",
-    "glob": "^7.0.5",
+    "glob": "^7.1.1",
     "js-codemod": "cpojer/js-codemod",
-    "jscodeshift": "^0.3.20",
+    "jscodeshift": "^0.3.29",
     "shopify-codemod": "latest",
     "shopify-decaf": "latest"
   }

--- a/packages/eslint-plugin-shopify/lib/config/all.js
+++ b/packages/eslint-plugin-shopify/lib/config/all.js
@@ -11,7 +11,7 @@ module.exports = {
   },
 
   parserOptions: {
-    ecmaVersion: 7,
+    ecmaVersion: 2017,
     sourceType: 'module',
     ecmaFeatures: {
       jsx: true,

--- a/packages/eslint-plugin-shopify/lib/config/ava.js
+++ b/packages/eslint-plugin-shopify/lib/config/ava.js
@@ -4,7 +4,7 @@ module.exports = {
   },
 
   parserOptions: {
-    ecmaVersion: 7,
+    ecmaVersion: 2017,
     sourceType: 'module',
   },
 

--- a/packages/eslint-plugin-shopify/lib/config/esnext.js
+++ b/packages/eslint-plugin-shopify/lib/config/esnext.js
@@ -9,7 +9,7 @@ module.exports = {
   },
 
   parserOptions: {
-    ecmaVersion: 2016,
+    ecmaVersion: 2017,
     sourceType: 'module',
     ecmaFeatures: {
       experimentalObjectRestSpread: true,

--- a/packages/eslint-plugin-shopify/lib/config/esnext.js
+++ b/packages/eslint-plugin-shopify/lib/config/esnext.js
@@ -9,7 +9,7 @@ module.exports = {
   },
 
   parserOptions: {
-    ecmaVersion: 7,
+    ecmaVersion: 2016,
     sourceType: 'module',
     ecmaFeatures: {
       experimentalObjectRestSpread: true,

--- a/packages/eslint-plugin-shopify/lib/config/flow.js
+++ b/packages/eslint-plugin-shopify/lib/config/flow.js
@@ -8,7 +8,7 @@ module.exports = {
   },
 
   parserOptions: {
-    ecmaVersion: 7,
+    ecmaVersion: 2017,
     sourceType: 'module',
   },
 
@@ -16,12 +16,6 @@ module.exports = {
     'flowtype',
     'shopify',
   ],
-
-  settings: {
-    flowtype: {
-      onlyFilesWithFlowAnnotation: true,
-    },
-  },
 
   rules: merge(
     require('./rules/flowtype')

--- a/packages/eslint-plugin-shopify/lib/config/rules/ava.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/ava.js
@@ -9,6 +9,10 @@ module.exports = {
   'ava/max-asserts': ['warn', 5],
   // Ensure no test.cb() is used.
   'ava/no-cb-test': 'warn',
+  // Ensure that async tests use await
+  'ava/no-async-fn-without-await': 'off',
+  // Ensure tests do not have duplicate modifiers.
+  'ava/no-duplicate-modifiers': 'error',
   // Ensure no tests have the same title.
   'ava/no-identical-title': 'error',
   // Ensure no tests are written in ignored files.

--- a/packages/eslint-plugin-shopify/lib/config/rules/best-practices.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/best-practices.js
@@ -7,6 +7,8 @@ module.exports = {
   'array-callback-return': 'error',
   // Treat var statements as if they were block scoped
   'block-scoped-var': 'warn',
+  // Enforce that class methods utilize this
+  'class-methods-use-this': 'warn',
   // Specify the maximum cyclomatic complexity allowed in a program
   'complexity': 'off',
   // Require return statements to either always or never specify values
@@ -94,6 +96,8 @@ module.exports = {
   'no-proto': 'error',
   // Disallow declaring the same variable more than once
   'no-redeclare': 'error',
+  // Disallow certain object properties
+  'no-restricted-properties': 'off',
   // Disallow use of assignment in return statement
   'no-return-assign': 'error',
   // Disallow use of javascript: urls.,

--- a/packages/eslint-plugin-shopify/lib/config/rules/ecmascript-6.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/ecmascript-6.js
@@ -39,6 +39,8 @@ module.exports = {
   'prefer-arrow-callback': ['error', {allowNamedFunctions: true}],
   // Suggest using of const declaration for variables that are never modified after declared
   'prefer-const': 'warn',
+  // Disallow parseInt() in favor of binary, octal, and hexadecimal literals
+  'prefer-numeric-literals': 'error',
   // Suggest using the rest parameters instead of arguments
   'prefer-rest-params': 'error',
   // Suggest using the spread operator instead of .apply()
@@ -51,6 +53,10 @@ module.exports = {
   'rest-spread-spacing': ['warn', 'never'],
   // Disallow generator functions that do not have yield
   'require-yield': 'error',
+  // Sort import declarations within module
+  'sort-imports': 'off',
+  // Require symbol descriptions
+  'symbol-description': 'warn',
   // Enforce spacing around embedded expressions of template strings
   'template-curly-spacing': ['warn', 'never'],
   // Enforce spacing around the * in yield* expressions

--- a/packages/eslint-plugin-shopify/lib/config/rules/flowtype.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/flowtype.js
@@ -9,6 +9,8 @@ module.exports = {
   'flowtype/delimiter-dangle': ['warn', 'always-multiline'],
   // Enforces consistent spacing within generic type annotation parameters.
   'flowtype/generic-spacing': ['warn', 'never'],
+  // Checks for duplicate properties in Object annotations
+  'flowtype/no-dupe-keys': 'error',
   // Warns against weak type annotations any, Object and Function.
   'flowtype/no-weak-types': ['error', {
     any: false,
@@ -20,9 +22,13 @@ module.exports = {
   // Requires that functions have return type annotation.
   'flowtype/require-return-type': 'off',
   // Makes sure that files have a valid @flow annotation.
-  'flowtype/require-valid-file-annotation': ['warn', 'always'],
+  'flowtype/require-valid-file-annotation': ['warn', 'always', {
+    annotationStyle: 'line',
+  }],
   // Enforces consistent use of semicolons after type aliases.
   'flowtype/semi': ['warn', 'always'],
+  // Enforces sorting of Object annotations
+  'flowtype/sort-keys': 'off',
   // Enforces consistent spacing after the type annotation colon.
   'flowtype/space-after-type-colon': ['warn', 'always'],
   // Enforces consistent spacing before the type annotation colon.

--- a/packages/eslint-plugin-shopify/lib/config/rules/flowtype.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/flowtype.js
@@ -22,9 +22,7 @@ module.exports = {
   // Requires that functions have return type annotation.
   'flowtype/require-return-type': 'off',
   // Makes sure that files have a valid @flow annotation.
-  'flowtype/require-valid-file-annotation': ['warn', 'always', {
-    annotationStyle: 'line',
-  }],
+  'flowtype/require-valid-file-annotation': ['warn', 'always'],
   // Enforces consistent use of semicolons after type aliases.
   'flowtype/semi': ['warn', 'always'],
   // Enforces sorting of Object annotations

--- a/packages/eslint-plugin-shopify/lib/config/rules/flowtype.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/flowtype.js
@@ -1,20 +1,38 @@
 // see https://github.com/gajus/eslint-plugin-flowtype
 
 module.exports = {
+  // Enforces a particular style for boolean type annotations.
+  'flowtype/boolean-style': ['warn', 'boolean'],
   // Marks Flow type identifiers as defined.
   'flowtype/define-flow-type': 'error',
+  // Enforces consistent use of trailing commas in Object and Tuple annotations.
+  'flowtype/delimiter-dangle': ['warn', 'always-multiline'],
+  // Enforces consistent spacing within generic type annotation parameters.
+  'flowtype/generic-spacing': ['warn', 'never'],
+  // Warns against weak type annotations any, Object and Function.
+  'flowtype/no-weak-types': ['error', {
+    any: false,
+    Object: false,
+    Function: true,
+  }],
   // Requires that all function parameters have type annotations.
   'flowtype/require-parameter-type': 'off',
   // Requires that functions have return type annotation.
   'flowtype/require-return-type': 'off',
   // Makes sure that files have a valid @flow annotation.
   'flowtype/require-valid-file-annotation': ['warn', 'always'],
+  // Enforces consistent use of semicolons after type aliases.
+  'flowtype/semi': ['warn', 'always'],
   // Enforces consistent spacing after the type annotation colon.
   'flowtype/space-after-type-colon': ['warn', 'always'],
   // Enforces consistent spacing before the type annotation colon.
   'flowtype/space-before-type-colon': ['warn', 'never'],
+  // Enforces consistent spacing before the opening < of generic type annotation parameters.
+  'flowtype/space-before-generic-bracket': ['warn', 'never'],
   // Enforces a consistent naming pattern for type aliases.
-  'flowtype/type-id-match': ['warn', '^([A-Z][a-z0-9]+)+(Type|Props|State|Context)$'],
+  'flowtype/type-id-match': ['warn', '^([A-Z][a-z0-9]*)*(Type|Props|State|Context)$'],
+  // Enforces consistent spacing around union and intersection type separators (| and &).
+  'flowtype/union-intersection-spacing': 'warn',
   // Marks Flow type alias declarations as used.
   'flowtype/use-flow-type': 'error',
   // Checks for simple Flow syntax errors.

--- a/packages/eslint-plugin-shopify/lib/config/rules/import.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/import.js
@@ -11,10 +11,16 @@ module.exports = {
   'import/default': 'error',
   // Ensure imported namespaces contain dereferenced properties as they are dereferenced.
   'import/namespace': 'error',
+  // Forbid require() calls with expressions
+  'import/no-dynamic-require': 'off',
+  // Prevent importing the submodules of other modules
+  'import/no-internal-modules': 'off',
   // Restrict which files can be imported in a given folder
   'import/no-restricted-paths': 'off',
   // Forbid import of modules using absolute paths
   'import/no-absolute-path': 'error',
+  // Forbid Webpack loader syntax in imports
+  'import/no-webpack-loader-syntax': 'error',
 
   // Helpful warnings
 
@@ -33,6 +39,8 @@ module.exports = {
 
   // Module systems
 
+  // Report potentially ambiguous parse goal (script vs. module)
+  'import/unambiguous': 'error',
   // Report CommonJS require calls and module.exports or exports.*.
   'import/no-commonjs': 'off',
   // Report AMD require and define calls.
@@ -43,7 +51,7 @@ module.exports = {
   // Style guide
 
   // Ensure all imports appear before other statements
-  'import/imports-first': 'warn',
+  'import/first': 'warn',
   // Report repeated import of the same module in multiple places
   'import/no-duplicates': 'error',
   // Report namespace imports
@@ -61,6 +69,8 @@ module.exports = {
   'import/newline-after-import': 'warn',
   // Prefer a default export if module exports a single name
   'import/prefer-default-export': 'off',
-  // Limit the maximum number of dependencies a module can have.
+  // Limit the maximum number of dependencies a module can have
   'import/max-dependencies': 'off',
+  // Forbid unassigned imports
+  'import/no-unassigned-import': 'off',
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/import.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/import.js
@@ -13,6 +13,8 @@ module.exports = {
   'import/namespace': 'error',
   // Restrict which files can be imported in a given folder
   'import/no-restricted-paths': 'off',
+  // Forbid import of modules using absolute paths
+  'import/no-absolute-path': 'error',
 
   // Helpful warnings
 
@@ -59,4 +61,6 @@ module.exports = {
   'import/newline-after-import': 'warn',
   // Prefer a default export if module exports a single name
   'import/prefer-default-export': 'off',
+  // Limit the maximum number of dependencies a module can have.
+  'import/max-dependencies': 'off',
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/import.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/import.js
@@ -40,7 +40,7 @@ module.exports = {
   // Module systems
 
   // Report potentially ambiguous parse goal (script vs. module)
-  'import/unambiguous': 'error',
+  'import/unambiguous': 'off',
   // Report CommonJS require calls and module.exports or exports.*.
   'import/no-commonjs': 'off',
   // Report AMD require and define calls.

--- a/packages/eslint-plugin-shopify/lib/config/rules/jsx-a11y.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/jsx-a11y.js
@@ -11,6 +11,8 @@ module.exports = {
   'jsx-a11y/aria-role': 'error',
   // Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
   'jsx-a11y/aria-unsupported-elements': 'error',
+  // Enforce a clickable non-interactive element has at least one keyboard event listener.
+  'jsx-a11y/click-events-have-key-events': 'error',
   // Enforce heading (h1, h2, etc) elements contain accessible content.
   'jsx-a11y/heading-has-content': 'error',
   // Enforce an anchor element's href prop value is not just #.
@@ -33,6 +35,8 @@ module.exports = {
   'jsx-a11y/no-marquee': 'error',
   // Enforce that onBlur is used instead of onChange.
   'jsx-a11y/no-onchange': 'off',
+  // Enforce non-interactive elements have no interactive handlers.
+  'jsx-a11y/no-static-element-interactions': 'off',
   // Enforce that elements with onClick handlers must be focusable.
   'jsx-a11y/onclick-has-focus': 'error',
   // Enforce that non-interactive, visible elements (such as <div>) that have click handlers use the role attribute.

--- a/packages/eslint-plugin-shopify/lib/config/rules/mocha.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/mocha.js
@@ -13,10 +13,18 @@ module.exports = {
   'mocha/no-global-tests': 'error',
   // Disallow hooks
   'mocha/no-hooks': 'off',
+  // Disallow hooks for a single test or test suite
+  'mocha/no-hooks-for-single-case': 'off',
+  // Disallow identical titles
+  'mocha/no-identical-title': 'warn',
   // Disallow arrow functions as arguments to mocha globals
   'mocha/no-mocha-arrows': 'off',
+  // Disallow returning in a test or hook function that uses a callback
+  'mocha/no-return-and-callback': 'error',
   // Disallow duplicate uses of a hook at the same level inside a describe
   'mocha/no-sibling-hooks': 'error',
+  // Disallow top-level hooks
+  'mocha/no-top-level-hooks': 'error',
   // Disallow synchronous tests.
   'mocha/no-synchronous-tests': 'off',
   // Match suite descriptions to match a pre-configured regular expression

--- a/packages/eslint-plugin-shopify/lib/config/rules/mocha.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/mocha.js
@@ -27,8 +27,12 @@ module.exports = {
   'mocha/no-top-level-hooks': 'error',
   // Disallow synchronous tests.
   'mocha/no-synchronous-tests': 'off',
+  // Disallow tests to be nested within other tests
+  'mocha/no-nested-tests': 'error',
   // Match suite descriptions to match a pre-configured regular expression
   'mocha/valid-suite-description': 'off',
   // Match test descriptions to match a pre-configured regular expression
   'mocha/valid-test-description': 'off',
+  // Limit the number of top-level suites in a single file
+  'mocha/max-top-level-suites': ['warn', {limit: 1}],
 };

--- a/packages/eslint-plugin-shopify/lib/config/rules/node.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/node.js
@@ -20,7 +20,7 @@ module.exports = {
   // Restrict usage of specified node modules
   'no-restricted-modules': 'off',
   // Disallow use of synchronous methods
-  'no-sync': 'warn',
+  'no-sync': 'off',
   // Enforce either module.exports or exports.
   'node/exports-style': ['warn', 'module.exports'],
   // Disallow deprecated API.

--- a/packages/eslint-plugin-shopify/lib/config/rules/node.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/node.js
@@ -14,23 +14,27 @@ module.exports = {
   // Disallow string concatenation with __dirname and __filename
   'no-path-concat': 'warn',
   // Disallow process.exit()
-  'no-process-exit': 'warn',
+  'no-process-exit': 'off',
   // Restrict usage of specified node imports
   'no-restricted-imports': 'off',
   // Restrict usage of specified node modules
   'no-restricted-modules': 'off',
   // Disallow use of synchronous methods
   'no-sync': 'warn',
+  // Enforce either module.exports or exports.
+  'node/exports-style': ['warn', 'module.exports'],
   // Disallow deprecated API.
   'node/no-deprecated-api': 'warn',
   // Disallow import and export declarations for files that don't exist.
   'node/no-missing-import': 'off',
   // Disallow require()s for files that don't exist.
-  'node/no-missing-require': 'error',
+  'node/no-missing-require': 'off',
   // Disallow import and export declarations for files that are not published.
   'node/no-unpublished-import': 'off',
+  // Disallow bin files that npm ignores.
+  'node/no-unpublished-bin': 'error',
   // Disallow require()s for files that are not published.
-  'node/no-unpublished-require': 'error',
+  'node/no-unpublished-require': 'off',
   // Disallow unsupported ECMAScript features on the specified version.
   'node/no-unsupported-features': 'off',
   // If you turn this rule on, ESLint comes to address process.exit() as throw in code path analysis.

--- a/packages/eslint-plugin-shopify/lib/config/rules/react.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/react.js
@@ -33,6 +33,8 @@ module.exports = {
   'react/no-string-refs': 'warn',
   // Prevent usage of unknown DOM property
   'react/no-unknown-property': 'off',
+  // Prevent definitions of unused prop types
+  'react/no-unused-prop-types': 'warn',
   // Enforce ES5 or ES6 class for React Components
   'react/prefer-es6-class': 'error',
   // Enforce stateless React Components to be written as a pure function
@@ -51,6 +53,8 @@ module.exports = {
   'react/sort-comp': 'off',
   // Enforce propTypes declarations alphabetical sorting
   'react/sort-prop-types': 'off',
+  // Enforce style prop value being an object
+  'react/style-prop-object': 'error',
 
   // JSX
 

--- a/packages/eslint-plugin-shopify/lib/config/rules/react.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/react.js
@@ -7,6 +7,8 @@ module.exports = {
   'react/forbid-component-props': 'warn',
   // Forbid certain propTypes
   'react/forbid-prop-types': ['error', {forbid: ['any', 'array']}],
+  // Prevent passing children as props
+  'react/no-children-prop': 'warn',
   // Prevent usage of dangerous JSX properties
   'react/no-danger': 'off',
   // Prevent problem with children and props.dangerouslySetInnerHTML
@@ -31,6 +33,8 @@ module.exports = {
   'react/no-set-state': 'off',
   // Prevent using string references in ref attribute.
   'react/no-string-refs': 'warn',
+  // Prevent invalid characters from appearing in markup
+  'react/no-unescaped-entities': 'error',
   // Prevent usage of unknown DOM property
   'react/no-unknown-property': 'off',
   // Prevent definitions of unused prop types

--- a/packages/eslint-plugin-shopify/lib/config/rules/sort-class-members.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/sort-class-members.js
@@ -9,16 +9,12 @@ module.exports = {
         '[properties]',
         '[conventional-private-properties]',
         'constructor',
-        '[public-instance-members]',
+        '[methods]',
         '[conventional-private-methods]',
         '[everything-else]',
       ],
       groups: {
         'static-members': [{static: true}],
-        'public-instance-members': [{
-          static: false,
-          name: '/[^_].+/',
-        }],
       },
       accessorPairPositioning: 'getThenSet',
     },

--- a/packages/eslint-plugin-shopify/lib/config/rules/stylistic-issues.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/stylistic-issues.js
@@ -47,6 +47,10 @@ module.exports = {
   'linebreak-style': 'off',
   // Enforces empty lines around comments
   'lines-around-comment': ['warn', {beforeBlockComment: true}],
+  // Require or disallow newlines around directives
+  'lines-around-directive': ['warn', 'always'],
+  // Enforce position of line comments
+  'line-comment-position': ['warn', 'above'],
   // Enforce a maximum file length
   'max-lines': 'off',
   // Specify the maximum depth callbacks can be nested
@@ -127,8 +131,6 @@ module.exports = {
   'semi': ['warn', 'always'],
   // Requires object keys to be sorted
   'sort-keys': 'off',
-  // Sort import declarations within module
-  'sort-imports': 'off',
   // Sort variables within the same declaration block
   'sort-vars': 'off',
   // Require or disallow space before blocks

--- a/packages/eslint-plugin-shopify/lib/config/rules/stylistic-issues.js
+++ b/packages/eslint-plugin-shopify/lib/config/rules/stylistic-issues.js
@@ -50,7 +50,7 @@ module.exports = {
   // Require or disallow newlines around directives
   'lines-around-directive': ['warn', 'always'],
   // Enforce position of line comments
-  'line-comment-position': ['warn', 'above'],
+  'line-comment-position': ['warn', {position: 'above'}],
   // Enforce a maximum file length
   'max-lines': 'off',
   // Specify the maximum depth callbacks can be nested

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -30,25 +30,25 @@
   },
   "devDependencies": {
     "eslint-find-rules": "1.x",
-    "eslint": "3.3.x"
+    "eslint": "3.5.x"
   },
   "peerDependencies": {
-    "eslint": "3.3.x"
+    "eslint": "3.5.x"
   },
   "dependencies": {
     "babel-eslint": "6.1.x",
     "eslint-plugin-ava": "3.0.x",
     "eslint-plugin-babel": "3.3.x",
     "eslint-plugin-chai-expect": "1.1.x",
-    "eslint-plugin-flowtype": "2.7.x",
-    "eslint-plugin-import": "1.13.x",
-    "eslint-plugin-jsx-a11y": "2.1.x",
+    "eslint-plugin-flowtype": "2.17.x",
+    "eslint-plugin-import": "1.15.x",
+    "eslint-plugin-jsx-a11y": "2.2.x",
     "eslint-plugin-lodash": "1.10.x",
-    "eslint-plugin-mocha": "4.3.x",
+    "eslint-plugin-mocha": "4.5.x",
     "eslint-plugin-node": "2.0.x",
     "eslint-plugin-promise": "2.0.x",
-    "eslint-plugin-react": "6.1.x",
-    "eslint-plugin-sort-class-members": "1.0.x",
+    "eslint-plugin-react": "6.2.x",
+    "eslint-plugin-sort-class-members": "1.1.x",
     "merge": "1.x"
   }
 }

--- a/packages/eslint-plugin-shopify/package.json
+++ b/packages/eslint-plugin-shopify/package.json
@@ -30,24 +30,25 @@
   },
   "devDependencies": {
     "eslint-find-rules": "1.x",
-    "eslint": "3.5.x"
+    "eslint-plugin-shopify": "file:.",
+    "eslint": "3.7.x"
   },
   "peerDependencies": {
-    "eslint": "3.5.x"
+    "eslint": "3.7.x"
   },
   "dependencies": {
-    "babel-eslint": "6.1.x",
-    "eslint-plugin-ava": "3.0.x",
+    "babel-eslint": "7.0.x",
+    "eslint-plugin-ava": "3.1.x",
     "eslint-plugin-babel": "3.3.x",
     "eslint-plugin-chai-expect": "1.1.x",
-    "eslint-plugin-flowtype": "2.17.x",
-    "eslint-plugin-import": "1.15.x",
+    "eslint-plugin-flowtype": "2.20.x",
+    "eslint-plugin-import": "2.0.x",
     "eslint-plugin-jsx-a11y": "2.2.x",
     "eslint-plugin-lodash": "1.10.x",
-    "eslint-plugin-mocha": "4.5.x",
-    "eslint-plugin-node": "2.0.x",
-    "eslint-plugin-promise": "2.0.x",
-    "eslint-plugin-react": "6.2.x",
+    "eslint-plugin-mocha": "4.7.x",
+    "eslint-plugin-node": "2.1.x",
+    "eslint-plugin-promise": "3.0.x",
+    "eslint-plugin-react": "6.4.x",
     "eslint-plugin-sort-class-members": "1.1.x",
     "merge": "1.x"
   }

--- a/packages/shopify-codemod/package.json
+++ b/packages/shopify-codemod/package.json
@@ -32,8 +32,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "jscodeshift": "^0.3.16",
-    "chai-jscodeshift": "file:../chai-jscodeshift"
+    "chai-jscodeshift": "file:../chai-jscodeshift",
+    "jscodeshift": "^0.3.29"
   },
   "dependencies": {
     "babel-preset-shopify": "latest"

--- a/packages/shopify-codemod/transforms/constructor-literal-assignment-to-class-property.js
+++ b/packages/shopify-codemod/transforms/constructor-literal-assignment-to-class-property.js
@@ -48,8 +48,10 @@ export default function constructorLiteralAssignmentToClassProperty({source}, {j
           j.classProperty(
             statement.get('expression', 'left', 'property').node,
             statement.get('expression', 'right').node,
-            null, // type annotation
-            statement.get('expression', 'left', 'object', 'type').value !== 'ThisExpression', // static
+            // type annotation
+            null,
+            // static
+            statement.get('expression', 'left', 'object', 'type').value !== 'ThisExpression',
           ),
         );
         statement.replace();


### PR DESCRIPTION
This PR updates all of our linting dependencies to their most recent versions and adds the new rules they introduced. Most notably, the following rules now apply:

- Line comments should be above the line they are commenting, not at the end of it (definitely open to discussion, wasn't sure about this one).
- Always include a description when using the `Symbol` function.
- A bunch of spacing-related rules for Flow.
- In Flow, prevent the usage of `Function` as a type (I chose not to restrict `Object` and `any` since I find them to be useful occasionally, not sure about it though).
- Prevent the usage of `done` and returning a promise together in mocha tests.
- Require whitespace around directives, like `'expose Foo'`.

cc/ @Shopify/javascript @bouk thoughts?
