### PR TITLE
Update babel presets

### DIFF
--- a/packages/babel-preset-shopify/index.js
+++ b/packages/babel-preset-shopify/index.js
@@ -1,7 +1,1 @@
-module.exports = {
-  presets: [
-    require('babel-preset-es2015'),
-    require('./non-standard-features'),
-    require('babel-preset-react'),
-  ],
-};
+module.exports = require('./web');

--- a/packages/babel-preset-shopify/node.js
+++ b/packages/babel-preset-shopify/node.js
@@ -2,7 +2,7 @@ var semver = require('semver');
 
 module.exports = function shopifyNodePreset(context, options) {
   options = options || {};
-  var version = options.version || '5.7.0';
+  var version = options.version || process.version;
   var modules = options.modules == null ? true : options.modules;
   var pluginsList = [];
 

--- a/packages/babel-preset-shopify/node.js
+++ b/packages/babel-preset-shopify/node.js
@@ -1,6 +1,40 @@
-module.exports = {
-  presets: [
-    require('babel-preset-es2015-node'),
-    require('./non-standard-features'),
-  ],
+var semver = require('semver');
+
+module.exports = function shopifyNodePreset(context, options) {
+  options = options || {};
+  var version = options.version || '5.7.0';
+  var modules = options.modules == null ? true : options.modules;
+  var pluginsList = [];
+
+  if (modules) {
+    pluginsList.push(
+      require('babel-plugin-transform-es2015-modules-commonjs')
+    );
+  }
+
+  if (semver.lt(version, '6.0.0')) {
+    pluginsList.push(
+      require('babel-plugin-transform-es2015-destructuring'),
+      require('babel-plugin-transform-es2015-function-name'),
+      require('babel-plugin-transform-es2015-parameters'),
+      require('babel-plugin-transform-es2015-shorthand-properties'),
+      require('babel-plugin-transform-es2015-sticky-regex'),
+      require('babel-plugin-transform-es2015-unicode-regex')
+    );
+  }
+
+  if (semver.lt(version, '5.0.0')) {
+    pluginsList.push(
+      require('babel-plugin-transform-es2015-spread')
+    );
+  }
+
+  return {
+    presets: [
+      {plugins: pluginsList},
+      require('babel-preset-es2016'),
+      require('babel-preset-es2017'),
+      require('./non-standard-features'),
+    ],
+  };
 };

--- a/packages/babel-preset-shopify/non-standard-features.js
+++ b/packages/babel-preset-shopify/non-standard-features.js
@@ -3,7 +3,6 @@ module.exports = {
     require('babel-preset-stage-2'),
   ],
   plugins: [
-    require('babel-plugin-transform-class-properties'),
     require('babel-plugin-transform-export-extensions'),
     require('babel-plugin-transform-inline-environment-variables'),
   ],

--- a/packages/babel-preset-shopify/package.json
+++ b/packages/babel-preset-shopify/package.json
@@ -17,12 +17,21 @@
     ]
   },
   "dependencies": {
-    "babel-plugin-transform-class-properties": "^6.9.0",
+    "babel-plugin-transform-es2015-destructuring": "^6.9.0",
+    "babel-plugin-transform-es2015-function-name": "^6.9.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.14.0",
+    "babel-plugin-transform-es2015-parameters": "^6.11.4",
+    "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
+    "babel-plugin-transform-es2015-spread": "^6.8.0",
+    "babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
+    "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
     "babel-plugin-transform-export-extensions": "^6.5.0",
     "babel-plugin-transform-inline-environment-variables": "^6.5.0",
     "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es2016": "^6.11.3",
+    "babel-preset-es2017": "^6.14.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
-    "babel-preset-es2015-node": "^6.1.0"
+    "semver": "^5.3.0"
   }
 }

--- a/packages/babel-preset-shopify/react.js
+++ b/packages/babel-preset-shopify/react.js
@@ -1,0 +1,5 @@
+module.exports = {
+  presets: [
+    require('babel-preset-react'),
+  ],
+};

--- a/packages/babel-preset-shopify/web.js
+++ b/packages/babel-preset-shopify/web.js
@@ -1,0 +1,12 @@
+module.exports = function shopifyWebPreset(context, options) {
+  options = options || {};
+
+  return {
+    presets: [
+      [require('babel-preset-es2015').buildPreset, options],
+      require('babel-preset-es2016'),
+      require('babel-preset-es2017'),
+      require('./non-standard-features'),
+    ],
+  };
+};


### PR DESCRIPTION
This PR updates how Shopify's Babel presets work. I know I kind of did this before and we decided not to separate them out so much, but I have some use cases where this makes sense and I feel like it is more in line with our linting configs.

Basically, it works like this:

- There are separate configs for Node, Web, and React projects, where React is totally usable with either of the other two. The default config is just the web config.

- The web config takes options, which it passes on to the `es2015` preset. This allows us to use the `{modules: false}` option for our config, which makes the preset work with Rollup and Webpack 2 tree shaking.

- The node option also takes options: `modules` (just like the web one), and `version` for specifying a desired version of Node. I was using a preset that just used `process.version` to check what plugins to add, but that didn't make sense since you usually develop in a more modern version of node than the one you build for. I just copied the logic into our own config so that you can manually specify the version.

I like this structure much better personally. It also enables things I've been working on: using Webpack 2 to do tree-shaked builds of both server and client bundles, both of which need the React transforms as well. The config just requires two lines instead of one for the client bundle, and the preset can actually be used for node without over-transforming stuff that doesn't need to be transformed:

```js
// client
{
  presets: [
    ['shopify/web', {modules: false}],
    'shopify/react',
  ],
};

// server
{
  presets: [
    ['shopify/node', {modules: false}],
    'shopify/react',
  ],
};
``` 

cc/ @Shopify/javascript @bouk thoughts?