### PR TITLE
Split up sequence assignments generated by decaf

### DIFF
--- a/packages/esify/lib/codemod.js
+++ b/packages/esify/lib/codemod.js
@@ -4,6 +4,7 @@ require('babel-register')({ignore: false});
 
 var TRANSFORMS = [
   {path: 'shopify-codemod/transforms/split-if-assignments'},
+  {path: 'shopify-codemod/transforms/split-assignment-sequences'},
   {path: 'shopify-codemod/transforms/coffeescript-soak-to-condition'},
   {path: 'shopify-codemod/transforms/ternary-statement-to-if-statement'},
   {path: 'shopify-codemod/transforms/remove-useless-return-from-test', test: true},

--- a/packages/shopify-codemod/docs/split-assignment-sequences.md
+++ b/packages/shopify-codemod/docs/split-assignment-sequences.md
@@ -11,7 +11,7 @@ jscodeshift -t shopify-codemod/transforms/split-assignment-sequences <file>
 ```js
 foo = options.foo, bar = options.bar, options;
 
-this.foo = opts.foo, bar = opts.bar, options;
+this.foo = opts.foo, bar = opts.bar, opts;
 
 // BECOMES:
 

--- a/packages/shopify-codemod/docs/split-assignment-sequences.md
+++ b/packages/shopify-codemod/docs/split-assignment-sequences.md
@@ -1,0 +1,23 @@
+### `split-assignment-sequences`
+
+Splits `decaf`-generated assignment sequences into individual expressions, and removes their useless trailing return value.
+
+```sh
+jscodeshift -t shopify-codemod/transforms/split-assignment-sequences <file>
+```
+
+#### Example
+
+```js
+foo = options.foo, bar = options.bar, options;
+
+this.foo = opts.foo, bar = opts.bar, options;
+
+// BECOMES:
+
+foo = options.foo
+bar = options.bar
+
+this.foo = opts.foo
+this.bar = opts.bar
+```

--- a/packages/shopify-codemod/test/fixtures/split-assignment-sequences/basic.input.js
+++ b/packages/shopify-codemod/test/fixtures/split-assignment-sequences/basic.input.js
@@ -1,0 +1,7 @@
+foo = options.foo, bar = options.bar, baz = options.baz, options
+
+this.foo = options.foo, this.bar = options.bar, options;
+
+function foo() {
+  bar = options.bar, quz = options.qux, options;
+}

--- a/packages/shopify-codemod/test/fixtures/split-assignment-sequences/basic.output.js
+++ b/packages/shopify-codemod/test/fixtures/split-assignment-sequences/basic.output.js
@@ -1,0 +1,10 @@
+foo = options.foo;
+bar = options.bar;
+baz = options.baz;
+this.foo = options.foo;
+this.bar = options.bar;
+
+function foo() {
+  bar = options.bar;
+  quz = options.qux;
+}

--- a/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-bodyless-sequences.input.js
+++ b/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-bodyless-sequences.input.js
@@ -1,0 +1,2 @@
+const foo = () =>
+  (foo = options.foo, bar = options.bar, options);

--- a/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-bodyless-sequences.output.js
+++ b/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-bodyless-sequences.output.js
@@ -1,0 +1,2 @@
+const foo = () =>
+  (foo = options.foo, bar = options.bar, options);

--- a/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-mismatched-assignment-sources.input.js
+++ b/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-mismatched-assignment-sources.input.js
@@ -1,0 +1,1 @@
+this.baz = options.baz, this.qux = options.qux, opts;

--- a/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-mismatched-assignment-sources.output.js
+++ b/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-mismatched-assignment-sources.output.js
@@ -1,0 +1,1 @@
+this.baz = options.baz, this.qux = options.qux, opts;

--- a/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-return-sequence-assignments.input.js
+++ b/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-return-sequence-assignments.input.js
@@ -1,0 +1,5 @@
+function foo() {
+  return this.baz = options.baz, this.qux == options.bar, options;
+}
+this.baz = options.baz, this.qux == options.bar, options;
+this.baz = options.baz, this.qux = _options.bar, options;

--- a/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-return-sequence-assignments.output.js
+++ b/packages/shopify-codemod/test/fixtures/split-assignment-sequences/ignore-return-sequence-assignments.output.js
@@ -1,0 +1,5 @@
+function foo() {
+  return this.baz = options.baz, this.qux == options.bar, options;
+}
+this.baz = options.baz, this.qux == options.bar, options;
+this.baz = options.baz, this.qux = _options.bar, options;

--- a/packages/shopify-codemod/test/transforms/split-assignment-sequences.test.js
+++ b/packages/shopify-codemod/test/transforms/split-assignment-sequences.test.js
@@ -1,0 +1,20 @@
+import 'test-helper';
+import splitAssignmentSequences from 'split-assignment-sequences';
+
+describe('splitAssignmentSequences', () => {
+  it('transforms assignment sequences', () => {
+    expect(splitAssignmentSequences).to.transform('split-assignment-sequences/basic');
+  });
+
+  it('ignores return assignment sequences', () => {
+    expect(splitAssignmentSequences).to.transform('split-assignment-sequences/ignore-return-sequence-assignments');
+  });
+
+  it('ignores sequences that reference other assignment sources', () => {
+    expect(splitAssignmentSequences).to.transform('split-assignment-sequences/ignore-mismatched-assignment-sources');
+  });
+
+  it('ignores sequences without a contining body', () => {
+    expect(splitAssignmentSequences).to.transform('split-assignment-sequences/ignore-bodyless-sequences');
+  });
+});

--- a/packages/shopify-codemod/transforms/remove-unused-expressions.js
+++ b/packages/shopify-codemod/transforms/remove-unused-expressions.js
@@ -12,7 +12,7 @@ export default function removeUnusedExpressions({source}, {jscodeshift: j}, {pri
   function isValidExpression(expressionPath) {
     const type = expressionPath.get('expression', 'type').value;
     return (
-      /^(?:Assignment|Call|New|Update|Yield)Expression$/.test(type) ||
+      /^(?:Assignment|Call|New|Update|Yield|Sequence)Expression$/.test(type) ||
       isValidUnaryExpression(expressionPath) ||
       isDirective(expressionPath)
     );

--- a/packages/shopify-codemod/transforms/split-assignment-sequences.js
+++ b/packages/shopify-codemod/transforms/split-assignment-sequences.js
@@ -1,0 +1,29 @@
+export default function splitAssignmentSequences({source}, {jscodeshift: j}, {printOptions = {quote: 'single'}}) {
+  return j(source)
+    .find(j.ExpressionStatement, {
+      expression: (node) => j.SequenceExpression.check(node),
+    })
+    .filter((path) => {
+      const expressions = path.value.expression.expressions;
+      const lastExpression = expressions[expressions.length - 1];
+      const otherExpressions = expressions.slice(0, -1);
+
+      return j.Identifier.check(lastExpression) &&
+        otherExpressions.every(j.AssignmentExpression.check) &&
+        otherExpressions.every((expression) =>
+          expression.right.object.name === lastExpression.name,
+        );
+    })
+    .replaceWith((path) => {
+      const expressions = path.value.expression.expressions;
+      expressions.pop();
+      expressions.forEach((expression) => {
+        path.insertBefore(
+          j.expressionStatement(expression),
+       );
+      });
+
+      return null;
+    })
+    .toSource(printOptions);
+}

--- a/packages/shopify-codemod/transforms/split-assignment-sequences.js
+++ b/packages/shopify-codemod/transforms/split-assignment-sequences.js
@@ -14,7 +14,7 @@ export default function splitAssignmentSequences({source}, {jscodeshift: j}, {pr
           expression.right.object.name === lastExpression.name,
         );
     })
-    .replaceWith((path) => {
+    .forEach((path) => {
       const expressions = path.value.expression.expressions;
       expressions.pop();
       expressions.forEach((expression) => {
@@ -23,7 +23,7 @@ export default function splitAssignmentSequences({source}, {jscodeshift: j}, {pr
        );
       });
 
-      return null;
+      path.replace(null);
     })
     .toSource(printOptions);
 }


### PR DESCRIPTION
`decaf` takes stuff like `{@foo, @bar} = opts` and turns it into a sequence like `foo = opts.food, bar = opts.bar, opts`.  This PR:
* Converts each assignment to its own expression
* Removes the trailing `opts`

Note, I haven't handled some edge cases because they have no value to Shopify's current codebase:
* Transforming `return foo = opts.foo, opts` to `foo = opts.foo; return opts`
* Checking that all assigned fields are identifiers with a name matching their source property

Please review @lemonmade, @TylerHorth 