### PR TITLE
Recast now adds arrow parens to single arg functions

### DIFF
--- a/packages/esify/lib/config.js
+++ b/packages/esify/lib/config.js
@@ -8,6 +8,7 @@ module.exports = function loadConfig() {
       appGlobalIdentifiers: ['Shopify', 'Sello'],
       javascriptSourceLocation: path.join(process.cwd(), 'app/assets/javascripts'),
       printOptions: {
+        arrowParensAlways: true,
         quote: 'single',
         trailingComma: true,
         tabWidth: 2,

--- a/packages/shopify-codemod/test/fixtures/split-return-assignments/inline.output.js
+++ b/packages/shopify-codemod/test/fixtures/split-return-assignments/inline.output.js
@@ -1,4 +1,4 @@
-foo(foo => {
+foo((foo) => {
   foo = bar;
   return foo;
 });

--- a/packages/shopify-codemod/test/test-helper.js
+++ b/packages/shopify-codemod/test/test-helper.js
@@ -5,7 +5,10 @@ import chaiJSCodeShift from 'chai-jscodeshift';
 chai.use(chaiJSCodeShift({
   fixtureDirectory: path.join(__dirname, 'fixtures'),
   transformOptions: {
-    printOptions: {quote: 'single'},
+    printOptions: {
+      arrowParensAlways: true,
+      quote: 'single',
+    },
     javascriptSourceLocation: path.join(__dirname, 'fixtures', 'javascripts'),
     appGlobalIdentifiers: ['App'],
   },


### PR DESCRIPTION
Makes `esify` generate parens for single argument arrow functions.  As Admin's linting config mandates parens, this'll make conversion a little easier.

This is achieved by passing around the `arrowParensAlways` option that [I added to `recast`](https://github.com/benjamn/recast/pull/288).  Go me.

Fixes #167 

Please review: @TylerHorth 
cc @lemonmade