### PR TITLE
Added guides for using Yarn to install deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Have a legacy codebase? Can’t use ESNext? Our [legacy styleguide](legacy/) is 
 
 ## Using this guide
 
-Many of the following rules are enforced by our [shared ESLint config/plugin](packages/eslint-plugin-shopify), which you can use in most editors and CI environments. To use it, you will need to have [Node.js >=5.7.0](https://docs.npmjs.com/getting-started/installing-node) and [Yarn](https://yarnpkg.com) installed. As an alternative to Yarn, you can use [NPM](https://docs.npmjs.com/) which ships with Node.js.
+Many of the following rules are enforced by our [shared ESLint config/plugin](packages/eslint-plugin-shopify), which you can use in most editors and CI environments. To use it, you will need to have [Node.js >=5.7.0](https://docs.npmjs.com/getting-started/installing-node) and [Yarn](https://yarnpkg.com) installed. As an alternative to Yarn, you can use [npm](https://docs.npmjs.com/) which ships with Node.js.
 
 Once these are installed, you must then install ESLint and the Shopify plugin:
 
@@ -46,7 +46,7 @@ Once these are installed, you must then install ESLint and the Shopify plugin:
 yarn add --dev eslint eslint-plugin-shopify
 ```
 
-**With NPM**
+**With npm**
 
 ```bash
 npm install eslint eslint-plugin-shopify --save-dev
@@ -85,7 +85,7 @@ And, finally, run your new script:
 yarn run lint
 ```
 
-**With NPM**
+**With npm**
 
 ```bash
 npm run lint

--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ Have a legacy codebase? Can’t use ESNext? Our [legacy styleguide](legacy/) is 
 
 ## Using this guide
 
-Many of the following rules are enforced by our [shared ESLint config/ plugin](packages/eslint-plugin-shopify), which you can use in most editors and CI environments. To use it, you will need to have [Node.js >=5.7.0 and npm installed](https://docs.npmjs.com/getting-started/installing-node). Once these are installed, you must then install ESLint and the Shopify plugin:
+Many of the following rules are enforced by our [shared ESLint config/plugin](packages/eslint-plugin-shopify), which you can use in most editors and CI environments. To use it, you will need to have [Node.js >=5.7.0](https://docs.npmjs.com/getting-started/installing-node) and [Yarn](https://yarnpkg.com) installed. As an alternative to Yarn, you can use [NPM](https://docs.npmjs.com/) which ships with Node.js.
+
+Once these are installed, you must then install ESLint and the Shopify plugin:
+
+**With Yarn**
+
+```bash
+yarn add --dev eslint eslint-plugin-shopify
+```
+
+**With NPM**
 
 ```bash
 npm install eslint eslint-plugin-shopify --save-dev
@@ -68,6 +78,14 @@ You can now use ESLint. The easiest way to do this is by adding a linting script
 ```
 
 And, finally, run your new script:
+
+**With Yarn**
+
+```bash
+yarn run lint
+```
+
+**With NPM**
 
 ```bash
 npm run lint

--- a/packages/babel-preset-shopify/README.md
+++ b/packages/babel-preset-shopify/README.md
@@ -8,6 +8,14 @@ Shopify’s org-wide set of Babel transforms.
 
 Install this package, as well as the parts of Babel you wish to use:
 
+**With Yarn**
+
+```bash
+yarn add --dev --exact babel-core babel-preset-shopify
+```
+
+**With NPM**
+
 ```bash
 npm install babel-core babel-preset-shopify --save-dev --save-exact
 ```

--- a/packages/babel-preset-shopify/README.md
+++ b/packages/babel-preset-shopify/README.md
@@ -14,7 +14,7 @@ Install this package, as well as the parts of Babel you wish to use:
 yarn add --dev --exact babel-core babel-preset-shopify
 ```
 
-**With NPM**
+**With npm**
 
 ```bash
 npm install babel-core babel-preset-shopify --save-dev --save-exact

--- a/packages/eslint-plugin-shopify/README.md
+++ b/packages/eslint-plugin-shopify/README.md
@@ -8,13 +8,27 @@ Shopify’s ESLint rules and configs.
 
 You'll first need to install [ESLint](http://eslint.org):
 
+**With Yarn**
+
+```bash
+yarn add --dev eslint
 ```
+
+**With NPM**
+
+```bash
 $ npm i eslint --save-dev
 ```
 
 Next, install `eslint-plugin-shopify`:
 
+**With Yarn**
+```bash
+yarn add --dev eslint-plugin-shopify
 ```
+
+**With NPM**
+```bash
 $ npm install eslint-plugin-shopify --save-dev
 ```
 

--- a/packages/eslint-plugin-shopify/README.md
+++ b/packages/eslint-plugin-shopify/README.md
@@ -14,7 +14,7 @@ You'll first need to install [ESLint](http://eslint.org):
 yarn add --dev eslint
 ```
 
-**With NPM**
+**With npm**
 
 ```bash
 $ npm i eslint --save-dev
@@ -27,7 +27,7 @@ Next, install `eslint-plugin-shopify`:
 yarn add --dev eslint-plugin-shopify
 ```
 
-**With NPM**
+**With npm**
 ```bash
 $ npm install eslint-plugin-shopify --save-dev
 ```


### PR DESCRIPTION
Closes https://github.com/Shopify/javascript/issues/253

This PR adds instructions for using Yarn to install some deps.

