### PR TITLE
Update 10.2 as per func-style allowArrowFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1225,6 +1225,9 @@ npm run lint
 
   // good
   function good() {}
+
+  // also good
+  const alsoGood = () => {}
   ```
 
 - [10.3](#10.3) <a name="10.3"></a> When using IIFEs, always wrap the function parentheses, with dangling parentheses for the function call.


### PR DESCRIPTION
This updates rule 10.2 following the change in https://github.com/Shopify/eslint-plugin-shopify/pull/188 allowing arrow function expressions.