### PR TITLE
Discourage the use of default exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1886,18 +1886,21 @@ npm run lint
 
 ### Modules
 
-- [12.14](#12.14) <a name="12.14"></a> Always use modules (`import`/ `export`) over a non-standard module system (CommonJS being the most popular of these).
+- [12.14](#12.14) <a name="12.14"></a> Always use modules (`import`/ `export`) with named exports over a different/non-standard module system (CommonJS being the most popular of these).
 
-  > Why? Modules are the future, so let’s get a head start. You can always transpile to a preferred module system.
+  Modules are the future, so let’s get a head start. You can always transpile to a preferred module system.
+
+  Avoid using `default` exports, consistently using named exports helps to keep naming and import style consistent across our repos.
 
   ```js
   // bad
   const BadImport = require('./BadImport');
   module.exports = BadImport.feelBadAboutIt();
+  export default BadImport();
 
   // good
-  import {feelGoodAboutIt} from './GoodImport';
-  export default feelGoodAboutIt();
+  export {feelGoodAboutIt, GoodImport} from './GoodImport';
+  export otherExport();
   ```
 
 - [12.15](#12.15) <a name="12.15"></a> Avoid complex relative import paths. It is usually fairly easy and much clearer to add the root of your project to the load path.

--- a/README.md
+++ b/README.md
@@ -1896,11 +1896,11 @@ npm run lint
   // bad
   const BadImport = require('./BadImport');
   module.exports = BadImport.feelBadAboutIt();
-  export default BadImport();
+  export default BadImport;
 
   // good
   export {feelGoodAboutIt, GoodImport} from './GoodImport';
-  export otherExport();
+  export otherExport;
   ```
 
 - [12.15](#12.15) <a name="12.15"></a> Avoid complex relative import paths. It is usually fairly easy and much clearer to add the root of your project to the load path.


### PR DESCRIPTION
IMO default exports confuse things by creating 2 ways to import/export components while offering no perceivable benefit/advantage.

I believe a world with only named imports would be more consistent, but I’m happy to hear and and all thoughts and opinions that are different (that's what PRs are for!).

`polaris-react` already enforces they not be used with the `import/no-default-export` rule (https://github.com/Shopify/polaris-react/issues/1959) and web-admin also shies away from them. 

Let's document it and make it official, OR be more specific about when and how they're used so we're consistent across repos.